### PR TITLE
MofGenerator fixes / integerValue, realValue support

### DIFF
--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -1,0 +1,67 @@
+﻿using Kingsland.MofParser.Ast;
+using Kingsland.MofParser.CodeGen;
+using Kingsland.MofParser.Parsing;
+using Kingsland.MofParser.Source;
+using Kingsland.MofParser.Tokens;
+using NUnit.Framework;
+
+namespace Kingsland.MofParser.UnitTests.CodeGen
+{
+
+    public static class MofGeneratorTests
+    {
+
+        public static class ConvertToMofTests
+        {
+
+            [Test]
+            public static void BooleanValueAstShouldRoundtrip()
+            {
+                var expectedMof =
+                    "instance of myType as $Alias00000070\r\n" +
+                    "{\r\n" +
+                    "    Reference = TRUE;\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            [Test]
+            public static void ClassDeclarationsAstWithQualifiersShouldRoundtrip()
+            {
+                var expectedMof =
+                   "[Abstract, OCL{\"-- the key property cannot be NULL\", \"inv: InstanceId.size() = 10\"}]\r\n" +
+                    "class GOLF_Base\r\n" +
+                    "{\r\n" +
+                    "\t[Description(\"an instance of a class that derives from the GOLF_Base class. \"), Key] string InstanceID;\r\n" +
+                    "\t[Description(\"A short textual description (one- line string) of the\"), MaxLen(64)] string Caption = Null;\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            [Test]
+            public static void ClassDeclarationsAstTestWithMofV2QualifierFlavorsShouldRoundtrip()
+            {
+                var expectedMof =
+                    "[Locale(1033): ToInstance, UUID(\"{BE46D060-7A7C-11d2-BC85-00104B2CF71C}\"): ToInstance]\r\n" +
+                    "class Win32_PrivilegesStatus : __ExtendedStatus\r\n" +
+                    "{\r\n" +
+                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesNotHeld[];\r\n" +
+                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesRequired[];\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+        }
+
+    }
+
+}

--- a/src/Kingsland.MofParser.UnitTests/Kingsland.MofParser.UnitTests.csproj
+++ b/src/Kingsland.MofParser.UnitTests/Kingsland.MofParser.UnitTests.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CodeGen\MofGeneratorTests.cs" />
     <Compile Include="Lexer\LexerHelper.cs" />
     <Compile Include="Lexer\LexerTests.cs" />
     <Compile Include="Parsing\ParserTests.cs" />

--- a/src/Kingsland.MofParser.UnitTests/Lexer/LexerHelper.cs
+++ b/src/Kingsland.MofParser.UnitTests/Lexer/LexerHelper.cs
@@ -10,34 +10,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
 
         public static void AssertAreEqual(Token expectedToken, Token actualToken)
         {
-            if ((expectedToken == null) && (actualToken == null))
-            {
-                return;
-            }
-            if (expectedToken == null)
-            {
-                Assert.Fail("expected is null, but actual is not null");
-            }
-            if (actualToken == null)
-            {
-                Assert.Fail("expected is not null, but actual is null");
-            }
-            Assert.AreEqual(expectedToken.GetType(), actualToken.GetType(),
-                $"actual type does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.StartPosition.Position, actualToken.Extent.StartPosition.Position,
-                $"actual Start Position does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.StartPosition.LineNumber, actualToken.Extent.StartPosition.LineNumber,
-                $"actual Start Line does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.StartPosition.ColumnNumber, actualToken.Extent.StartPosition.ColumnNumber,
-                $"actual Start Column does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.EndPosition.Position, actualToken.Extent.EndPosition.Position,
-                $"actual End Position does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.EndPosition.LineNumber, actualToken.Extent.EndPosition.LineNumber,
-                $"actual End Line does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.EndPosition.ColumnNumber, actualToken.Extent.EndPosition.ColumnNumber,
-                $"actual End Column does not match expected value");
-            Assert.AreEqual(expectedToken.Extent.Text, actualToken.Extent.Text,
-                $"actual Text does not match expected value");
+            LexerHelper.AssertAreEqualInternal(expectedToken, actualToken);
         }
 
         public static void AssertAreEqual(List<Token> expectedTokens, List<Token> actualTokens)
@@ -56,38 +29,178 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
             for (var i = 0; i < Math.Min(expectedTokens.Count, actualTokens.Count); i++)
             {
-                var expectedToken = expectedTokens[i];
-                var actualToken = actualTokens[i];
-                if ((expectedToken == null) && (actualToken == null))
-                {
-                    return;
-                }
-                if (expectedToken == null)
-                {
-                    Assert.Fail($"expected is null, but actual is not null at index {i}");
-                }
-                if (actualToken == null)
-                {
-                    Assert.Fail($"expected is not null, but actual is null at index {i}");
-                }
-                Assert.AreEqual(expectedToken.GetType(), actualToken.GetType(),
-                    $"actual type does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.StartPosition.Position, actualToken.Extent.StartPosition.Position,
-                    $"actual Start Position does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.StartPosition.LineNumber, actualToken.Extent.StartPosition.LineNumber,
-                    $"actual Start Line does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.StartPosition.ColumnNumber, actualToken.Extent.StartPosition.ColumnNumber,
-                    $"actual Start Column does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.EndPosition.Position, actualToken.Extent.EndPosition.Position,
-                    $"actual End Position does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.EndPosition.LineNumber, actualToken.Extent.EndPosition.LineNumber,
-                    $"actual End Line does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.EndPosition.ColumnNumber, actualToken.Extent.EndPosition.ColumnNumber,
-                    $"actual End Column does not match expected value at index {i}");
-                Assert.AreEqual(expectedToken.Extent.Text, actualToken.Extent.Text,
-                    $"actual Text does not match expected value at index {i}");
+                LexerHelper.AssertAreEqualInternal(expectedTokens[i], actualTokens[i], i);
             }
             Assert.AreEqual(expectedTokens.Count, actualTokens.Count, "expected and actual are different lengths");
+        }
+
+        private static void AssertAreEqualInternal(Token expectedToken, Token actualToken, int index = -1)
+        {
+            if ((expectedToken == null) && (actualToken == null))
+            {
+                return;
+            }
+            if (expectedToken == null)
+            {
+                Assert.Fail(LexerHelper.GetAssertErrorMessage("expected is null, but actual is not null", index));
+            }
+            if (actualToken == null)
+            {
+                Assert.Fail(LexerHelper.GetAssertErrorMessage("expected is not null, but actual is null", index));
+            }
+            Assert.AreEqual(expectedToken.GetType(), actualToken.GetType(),
+                LexerHelper.GetAssertErrorMessage($"actual type does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.StartPosition.Position, actualToken.Extent.StartPosition.Position,
+                LexerHelper.GetAssertErrorMessage($"actual Start Position does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.StartPosition.LineNumber, actualToken.Extent.StartPosition.LineNumber,
+                LexerHelper.GetAssertErrorMessage($"actual Start Line does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.StartPosition.ColumnNumber, actualToken.Extent.StartPosition.ColumnNumber,
+                LexerHelper.GetAssertErrorMessage($"actual Start Column does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.EndPosition.Position, actualToken.Extent.EndPosition.Position,
+                LexerHelper.GetAssertErrorMessage($"actual End Position does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.EndPosition.LineNumber, actualToken.Extent.EndPosition.LineNumber,
+                LexerHelper.GetAssertErrorMessage($"actual End Line does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.EndPosition.ColumnNumber, actualToken.Extent.EndPosition.ColumnNumber,
+                LexerHelper.GetAssertErrorMessage($"actual End Column does not match expected value", index));
+            Assert.AreEqual(expectedToken.Extent.Text, actualToken.Extent.Text,
+                LexerHelper.GetAssertErrorMessage($"actual Text does not match expected value", index));
+            switch (expectedToken)
+            {
+                case AliasIdentifierToken token:
+                    Assert.IsTrue(
+                        AliasIdentifierToken.AreEqual((AliasIdentifierToken)expectedToken, (AliasIdentifierToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case AttributeCloseToken token:
+                    Assert.IsTrue(
+                        AttributeCloseToken.AreEqual((AttributeCloseToken)expectedToken, (AttributeCloseToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case AttributeOpenToken token:
+                    Assert.IsTrue(
+                        AttributeOpenToken.AreEqual((AttributeOpenToken)expectedToken, (AttributeOpenToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case BlockCloseToken token:
+                    Assert.IsTrue(
+                        BlockCloseToken.AreEqual((BlockCloseToken)expectedToken, (BlockCloseToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case BlockOpenToken token:
+                    Assert.IsTrue(
+                        BlockOpenToken.AreEqual((BlockOpenToken)expectedToken, (BlockOpenToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case BooleanLiteralToken token:
+                    Assert.IsTrue(
+                        BooleanLiteralToken.AreEqual((BooleanLiteralToken)expectedToken, (BooleanLiteralToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case ColonToken token:
+                    Assert.IsTrue(
+                        ColonToken.AreEqual((ColonToken)expectedToken, (ColonToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case CommaToken token:
+                    Assert.IsTrue(
+                        CommaToken.AreEqual((CommaToken)expectedToken, (CommaToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case CommentToken token:
+                    Assert.IsTrue(
+                        CommentToken.AreEqual((CommentToken)expectedToken, (CommentToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case EqualsOperatorToken token:
+                    Assert.IsTrue(
+                        EqualsOperatorToken.AreEqual((EqualsOperatorToken)expectedToken, (EqualsOperatorToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case IdentifierToken token:
+                    Assert.IsTrue(
+                        IdentifierToken.AreEqual((IdentifierToken)expectedToken, (IdentifierToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case IntegerLiteralToken token:
+                    Assert.IsTrue(
+                        IntegerLiteralToken.AreEqual((IntegerLiteralToken)expectedToken, (IntegerLiteralToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case NullLiteralToken token:
+                    Assert.IsTrue(
+                        NullLiteralToken.AreEqual((NullLiteralToken)expectedToken, (NullLiteralToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case ParenthesesCloseToken token:
+                    Assert.IsTrue(
+                        ParenthesesCloseToken.AreEqual((ParenthesesCloseToken)expectedToken, (ParenthesesCloseToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case ParenthesesOpenToken token:
+                    Assert.IsTrue(
+                        ParenthesesOpenToken.AreEqual((ParenthesesOpenToken)expectedToken, (ParenthesesOpenToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case PragmaToken token:
+                    Assert.IsTrue(
+                        PragmaToken.AreEqual((PragmaToken)expectedToken, (PragmaToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case RealLiteralToken token:
+                    Assert.IsTrue(
+                        RealLiteralToken.AreEqual((RealLiteralToken)expectedToken, (RealLiteralToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case StatementEndToken token:
+                    Assert.IsTrue(
+                        StatementEndToken.AreEqual((StatementEndToken)expectedToken, (StatementEndToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case StringLiteralToken token:
+                    Assert.IsTrue(
+                        StringLiteralToken.AreEqual((StringLiteralToken)expectedToken, (StringLiteralToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                case WhitespaceToken token:
+                    Assert.IsTrue(
+                        WhitespaceToken.AreEqual((WhitespaceToken)expectedToken, (WhitespaceToken)actualToken),
+                        LexerHelper.GetAssertErrorMessage($"actual token does not match expected token", index)
+                    );
+                    break;
+                default:
+                    throw new NotImplementedException($"Cannot compare type '{expectedToken.GetType().Name}'");
+            }
+        }
+
+        private static string GetAssertErrorMessage(string message, int index = -1)
+        {
+            if (index == -1)
+            {
+                return message;
+            }
+            else
+            {
+                return $"{message} at index {index}";
+            }
         }
 
     }

--- a/src/Kingsland.MofParser.UnitTests/Lexer/LexerTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Lexer/LexerTests.cs
@@ -1077,7 +1077,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new SourcePosition(17, 1, 18),
                             "$myAliasIdentifier"
                         ),
-                        "$myAliasIdentifier"
+                        "myAliasIdentifier"
                     ),
                     new WhitespaceToken(
                         new SourceExtent
@@ -1094,7 +1094,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new SourcePosition(38, 2, 19),
                             "$myAliasIdentifier2"
                         ),
-                        "$myAliasIdentifier2"
+                        "myAliasIdentifier2"
                     )
                 };
                 LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
@@ -1189,7 +1189,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new SourcePosition(48, 1, 49),
                             "$cTentacleAgent1ref"
                         ),
-                        "$cTentacleAgent1ref"
+                        "cTentacleAgent1ref"
                     ),
                     new WhitespaceToken(
                         new SourceExtent
@@ -1241,8 +1241,356 @@ namespace Kingsland.MofParser.UnitTests.Lexer
         public static class ReadIntegerLiteralTokenMethod
         {
 
+            // binaryValue
+
             [Test]
-            public static void ShouldReadInteger0()
+            public static void ShouldReadBinaryValue0b()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0b")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(1, 1, 2),
+                            "0b"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadBinaryValue1b()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("1b")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(1, 1, 2),
+                            "1b"
+                        ),
+                        1
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadBinaryValue00000b()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("00000b")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "00000b"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadBinaryValue10000b()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("10000b")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "10000b"
+                        ),
+                        16
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadBinaryValue11111b()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("11111b")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "11111b"
+                        ),
+                        31
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            // octalValue
+
+            [Test]
+            public static void ShouldReadOctalValue00()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("00")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(1, 1, 2),
+                            "00"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadOctalValue01()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("01")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(1, 1, 2),
+                            "01"
+                        ),
+                        1
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadOctalValue00000()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("00000")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(4, 1, 5),
+                            "00000"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadOctalValue01000()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("01000")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(4, 1, 5),
+                            "01000"
+                        ),
+                        512
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadOctalValue01111()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("01111")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(4, 1, 5),
+                            "01111"
+                        ),
+                        585
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadOctalValue04444()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("04444")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(4, 1, 5),
+                            "04444"
+                        ),
+                        2340
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadOctalValue07777()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("07777")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(4, 1, 5),
+                            "07777"
+                        ),
+                        4095
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            // hexValue
+
+            [Test]
+            public static void ShouldReadHexValue0x0()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0x0")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(2, 1, 3),
+                            "0x0"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadHexValue0x0000()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0x0000")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "0x0000"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadHexValue0x8888()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0x8888")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "0x8888"
+                        ),
+                        34952
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadHexValue0xabcd()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0xabcd")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "0xabcd"
+                        ),
+                        43981
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadHexValue0xABCD()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0xABCD")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "0xABCD"
+                        ),
+                        43981
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            // decimalValue
+
+            [Test]
+            public static void ShouldReadDecimalValue0()
             {
                 var actualTokens = Lexing.Lexer.Lex(
                     SourceReader.From("0")
@@ -1262,7 +1610,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ShouldReadInteger12345()
+            public static void ShouldReadDecimalValue12345()
             {
                 var actualTokens = Lexing.Lexer.Lex(
                     SourceReader.From("12345")
@@ -1282,27 +1630,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ShouldReadIntegerMinus12345()
-            {
-                var actualTokens = Lexing.Lexer.Lex(
-                    SourceReader.From("-12345")
-                );
-                var expectedTokens = new List<Token> {
-                    new IntegerLiteralToken(
-                        new SourceExtent
-                        (
-                            new SourcePosition(0, 1, 1),
-                            new SourcePosition(5, 1, 6),
-                            "-12345"
-                        ),
-                        -12345
-                    )
-                };
-                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
-            }
-
-            [Test]
-            public static void ShouldReadIntegerPlus12345()
+            public static void ShouldReadDecimalValuePlus12345()
             {
                 var actualTokens = Lexing.Lexer.Lex(
                     SourceReader.From("+12345")
@@ -1322,7 +1650,27 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ShouldReadInteger1234567890()
+            public static void ShouldReadDecimalValueMinus12345()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("-12345")
+                );
+                var expectedTokens = new List<Token> {
+                    new IntegerLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "-12345"
+                        ),
+                        -12345
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadDecimalValue1234567890()
             {
                 var actualTokens = Lexing.Lexer.Lex(
                     SourceReader.From("1234567890")
@@ -1336,6 +1684,171 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             "1234567890"
                         ),
                         1234567890
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+        }
+
+        [TestFixture]
+        public static class ReadRealLiteralTokenMethod
+        {
+
+            [Test]
+            public static void ShouldReadRealValue0_0()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("0.0")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(2, 1, 3),
+                            "0.0"
+                        ),
+                        0
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValue123_45()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("123.45")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(5, 1, 6),
+                            "123.45"
+                        ),
+                        123.45
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValuePlus123_45()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("+123.45")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(6, 1, 7),
+                            "+123.45"
+                        ),
+                        123.45
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValueMinus123_45()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("-123.45")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(6, 1, 7),
+                            "-123.45"
+                        ),
+                        -123.45
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValue1234567890_00()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("1234567890.00")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent(
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(12, 1, 13),
+                            "1234567890.00"
+                        ),
+                        1234567890.00
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValue_45()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From(".45")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(2, 1, 3),
+                            ".45"
+                        ),
+                        0.45
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValuePlus_45()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("+.45")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(3, 1, 4),
+                            "+.45"
+                        ),
+                        0.45
+                    )
+                };
+                LexerHelper.AssertAreEqual(expectedTokens, actualTokens);
+            }
+
+            [Test]
+            public static void ShouldReadRealValueMinus_45()
+            {
+                var actualTokens = Lexing.Lexer.Lex(
+                    SourceReader.From("-.45")
+                );
+                var expectedTokens = new List<Token> {
+                    new RealLiteralToken(
+                        new SourceExtent
+                        (
+                            new SourcePosition(0, 1, 1),
+                            new SourcePosition(3, 1, 4),
+                            "-.45"
+                        ),
+                        -0.45
                     )
                 };
                 LexerHelper.AssertAreEqual(expectedTokens, actualTokens);

--- a/src/Kingsland.MofParser.UnitTests/Lexer/LexerTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Lexer/LexerTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 namespace Kingsland.MofParser.UnitTests.Lexer
 {
 
+    [TestFixture]
     public static class LexerTests
     {
 

--- a/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
@@ -497,7 +497,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
         public static class ParseMethodGolfExamples
         {
 
-            [Test, TestCaseSource(typeof(ParseMethodGolfExamples), "GetTestCases")]
+            //[Test, TestCaseSource(typeof(ParseMethodGolfExamples), "GetTestCases")]
             public static void ParseMethodTestsFromDisk(string mofFilename)
             {
                 //Console.WriteLine(mofFilename);

--- a/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
@@ -19,7 +19,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
         {
 
             [Test]
-            public static void ParsePropetyValueLiteralString()
+            public static void ParsePropetyValueWithLiteralString()
             {
                 var tokens = Lexing.Lexer.Lex(
                     SourceReader.From(
@@ -37,11 +37,35 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new InstanceValueDeclarationAst(
                                 new IdentifierToken(
                                     new SourceExtent(
+                                        new SourcePosition(0, 1, 1),
+                                        new SourcePosition(7, 1, 8),
+                                        "instance"
+                                    ),
+                                    "instance"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(9, 1, 10),
+                                        new SourcePosition(10, 1, 11),
+                                        "of"
+                                    ),
+                                    "of"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
                                         new SourcePosition(12, 1, 13),
                                         new SourcePosition(17, 1, 18),
                                         "myType"
                                     ),
                                     "myType"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(19, 1, 20),
+                                        new SourcePosition(20, 1, 21),
+                                        "as"
+                                    ),
+                                    "as"
                                 ),
                                 new AliasIdentifierToken(
                                     new SourceExtent(
@@ -57,6 +81,13 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                                             { "ServerURL", new StringValueAst("https://URL") }
                                         }
                                     )
+                                ),
+                                new StatementEndToken(
+                                    new SourceExtent(
+                                        new SourcePosition(74, 4, 2),
+                                        new SourcePosition(74, 4, 2),
+                                        ";"
+                                    )
                                 )
                             )
                         }
@@ -68,7 +99,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ParsePropetyValueWithReferenceTypeValue()
+            public static void ParsePropetyValueWithAliasIdentifier()
             {
                 var tokens = Lexing.Lexer.Lex(
                     SourceReader.From(
@@ -86,11 +117,35 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new InstanceValueDeclarationAst(
                                 new IdentifierToken(
                                     new SourceExtent(
+                                        new SourcePosition(0, 1, 1),
+                                        new SourcePosition(7, 1, 8),
+                                        "instance"
+                                    ),
+                                    "instance"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(9, 1, 10),
+                                        new SourcePosition(10, 1, 11),
+                                        "of"
+                                    ),
+                                    "of"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
                                         new SourcePosition(12, 1, 13),
                                         new SourcePosition(17, 1, 18),
                                         "myType"
                                     ),
                                     "myType"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(19, 1, 20),
+                                        new SourcePosition(20, 1, 21),
+                                        "as"
+                                    ),
+                                    "as"
                                 ),
                                 new AliasIdentifierToken(
                                     new SourceExtent(
@@ -103,8 +158,34 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                                 new PropertyValueListAst(
                                     new ReadOnlyDictionary<string, PropertyValueAst>(
                                         new Dictionary<string, PropertyValueAst> {
-                                            { "Reference", new ReferenceTypeValueAst("Alias0000006E") }
-                                        }
+                                            { "Reference", new ComplexValueAst(
+                                                true, false,
+                                                new AliasIdentifierToken(
+                                                    new SourceExtent(
+                                                        new SourcePosition(57, 3, 17),
+                                                        new SourcePosition(70, 3, 30),
+                                                        "$Alias0000006E"
+                                                    ),
+                                                    "Alias0000006E"
+                                                ),
+                                                new IdentifierToken(
+                                                    new SourceExtent(
+                                                        new SourcePosition(12, 1, 13),
+                                                        new SourcePosition(17, 1, 18),
+                                                        "myType"
+                                                    ),
+                                                    "myType"
+                                                ),
+                                                null
+                                            )
+                                        }}
+                                    )
+                                ),
+                                new StatementEndToken(
+                                    new SourceExtent(
+                                        new SourcePosition(75, 4, 2),
+                                        new SourcePosition(75, 4, 2),
+                                        ";"
                                     )
                                 )
                             )
@@ -117,7 +198,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ParsePropetyValueEmptyArray()
+            public static void ParsePropetyValueWithEmptyArray()
             {
                 var tokens = Lexing.Lexer.Lex(
                     SourceReader.From(
@@ -135,11 +216,35 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new InstanceValueDeclarationAst(
                                 new IdentifierToken(
                                     new SourceExtent(
+                                        new SourcePosition(0, 1, 1),
+                                        new SourcePosition(7, 1, 8),
+                                        "instance"
+                                    ),
+                                    "instance"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(9, 1, 10),
+                                        new SourcePosition(10, 1, 11),
+                                        "of"
+                                    ),
+                                    "of"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
                                         new SourcePosition(12, 1, 13),
                                         new SourcePosition(17, 1, 18),
                                         "myType"
                                     ),
                                     "myType"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(19, 1, 20),
+                                        new SourcePosition(20, 1, 21),
+                                        "as"
+                                    ),
+                                    "as"
                                 ),
                                 new AliasIdentifierToken(
                                     new SourceExtent(
@@ -152,12 +257,15 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                                 new PropertyValueListAst(
                                     new ReadOnlyDictionary<string, PropertyValueAst>(
                                         new Dictionary<string, PropertyValueAst> {
-                                            { "Reference", new ComplexValueArrayAst(
-                                                new ReadOnlyCollection<ComplexValueAst>(
-                                                    new List<ComplexValueAst>()
-                                                ))
-                                            }
+                                            { "Reference", new LiteralValueArrayAst(null) }
                                         }
+                                    )
+                                ),
+                                new StatementEndToken(
+                                    new SourceExtent(
+                                        new SourcePosition(63, 4, 2),
+                                        new SourcePosition(63, 4, 2),
+                                        ";"
                                     )
                                 )
                             )
@@ -170,7 +278,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ParsePropetyValueArrayWithSingleItem()
+            public static void ParsePropetyValueArrayWithAliasIdentifier()
             {
                 var tokens = Lexing.Lexer.Lex(
                     SourceReader.From(
@@ -188,11 +296,35 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new InstanceValueDeclarationAst(
                                 new IdentifierToken(
                                     new SourceExtent(
+                                        new SourcePosition(0, 1, 1),
+                                        new SourcePosition(7, 1, 8),
+                                        "instance"
+                                    ),
+                                    "instance"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(9, 1, 10),
+                                        new SourcePosition(10, 1, 11),
+                                        "of"
+                                    ),
+                                    "of"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
                                         new SourcePosition(12, 1, 13),
                                         new SourcePosition(17, 1, 18),
                                         "myType"
                                     ),
                                     "myType"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(19, 1, 20),
+                                        new SourcePosition(20, 1, 21),
+                                        "as"
+                                    ),
+                                    "as"
                                 ),
                                 new AliasIdentifierToken(
                                     new SourceExtent(
@@ -226,16 +358,19 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                                                                 ),
                                                                 "myType"
                                                             ),
-                                                            new PropertyValueListAst(
-                                                                new ReadOnlyDictionary<string, PropertyValueAst>(
-                                                                    new Dictionary<string, PropertyValueAst>()
-                                                                )
-                                                            )
+                                                            null
                                                         )
                                                     }
                                                 )
                                             )}
                                         }
+                                    )
+                                ),
+                                new StatementEndToken(
+                                    new SourceExtent(
+                                        new SourcePosition(77, 4, 2),
+                                        new SourcePosition(77, 4, 2),
+                                        ";"
                                     )
                                 )
                             )
@@ -248,7 +383,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
             }
 
             [Test]
-            public static void ParsePropetyValueArrayWithMultipleItems()
+            public static void ParsePropetyValueArrayWitLiteralStrings()
             {
                 var tokens = Lexing.Lexer.Lex(
                     SourceReader.From(
@@ -266,11 +401,35 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                             new InstanceValueDeclarationAst(
                                 new IdentifierToken(
                                     new SourceExtent(
+                                        new SourcePosition(0, 1, 1),
+                                        new SourcePosition(7, 1, 8),
+                                        "instance"
+                                    ),
+                                    "instance"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(9, 1, 10),
+                                        new SourcePosition(10, 1, 11),
+                                        "of"
+                                    ),
+                                    "of"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
                                         new SourcePosition(12, 1, 13),
                                         new SourcePosition(17, 1, 18),
                                         "myType"
                                     ),
                                     "myType"
+                                ),
+                                new IdentifierToken(
+                                    new SourceExtent(
+                                        new SourcePosition(19, 1, 20),
+                                        new SourcePosition(20, 1, 21),
+                                        "as"
+                                    ),
+                                    "as"
                                 ),
                                 new AliasIdentifierToken(
                                     new SourceExtent(
@@ -292,6 +451,13 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                                                 )
                                             )}
                                         }
+                                    )
+                                ),
+                                new StatementEndToken(
+                                    new SourceExtent(
+                                        new SourcePosition(96, 4, 2),
+                                        new SourcePosition(96, 4, 2),
+                                        ";"
                                     )
                                 )
                             )
@@ -331,7 +497,7 @@ namespace Kingsland.MofParser.UnitTests.Lexer
         public static class ParseMethodGolfExamples
         {
 
-            //[Test, TestCaseSource(typeof(ParseMethodGolfExamples), "GetTestCases")]
+            [Test, TestCaseSource(typeof(ParseMethodGolfExamples), "GetTestCases")]
             public static void ParseMethodTestsFromDisk(string mofFilename)
             {
                 //Console.WriteLine(mofFilename);

--- a/src/Kingsland.MofParser/Ast/BooleanValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/BooleanValueAst.cs
@@ -14,6 +14,7 @@ namespace Kingsland.MofParser.Ast
     /// 7.6.1.5 Boolean value
     ///
     ///     booleanValue = TRUE / FALSE
+    ///
     ///     FALSE        = "false" ; keyword: case insensitive
     ///     TRUE         = "true"  ; keyword: case insensitive
     ///
@@ -74,7 +75,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertBooleanValueAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/ClassDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/ClassDeclarationAst.cs
@@ -22,6 +22,7 @@ namespace Kingsland.MofParser.Ast
     ///     superClass       = ":" className
     ///     classFeature     = structureFeature /
     ///                        methodDeclaration
+    ///
     ///     CLASS            = "class" ; keyword: case insensitive
     ///
     /// </remarks>
@@ -84,7 +85,7 @@ namespace Kingsland.MofParser.Ast
         {
             this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
             this.ClassName = className ?? throw new ArgumentNullException(nameof(className));
-            this.Superclass = superClass ?? throw new ArgumentNullException(nameof(superClass));
+            this.Superclass = superClass;
             this.Features = features ?? new ReadOnlyCollection<ClassFeatureAst>(new List<ClassFeatureAst>());
         }
 
@@ -122,7 +123,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertClassDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/CompilerDirectiveAst.cs
+++ b/src/Kingsland.MofParser/Ast/CompilerDirectiveAst.cs
@@ -26,6 +26,7 @@ namespace Kingsland.MofParser.Ast
     ///                                      ; the parameter value
     ///                                      ; shall represent a relative
     ///                                      ; or full file path
+    ///
     ///     PRAGMA             = "#pragma"  ; keyword: case insensitive
     ///     INCLUDE            = "include"  ; keyword: case insensitive
     ///
@@ -94,7 +95,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertCompilerDirectiveAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/ComplexValueArrayAst.cs
+++ b/src/Kingsland.MofParser/Ast/ComplexValueArrayAst.cs
@@ -74,7 +74,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertComplexValueArrayAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/ComplexValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/ComplexValueAst.cs
@@ -12,10 +12,10 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.5.9 Complex type value
     ///
-    ///     complexValue      = aliasIdentifier /
-    ///                         ( VALUE OF
-    ///                           ( structureName / className / associationName )
-    ///                           propertyValueList )
+    ///     complexValue = aliasIdentifier /
+    ///                    ( VALUE OF
+    ///                      ( structureName / className / associationName )
+    ///                      propertyValueList )
     ///
     /// </remarks>
     public sealed class ComplexValueAst : ComplexTypeValueAst
@@ -128,7 +128,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertComplexValueAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/InstanceValueDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/InstanceValueDeclarationAst.cs
@@ -30,11 +30,25 @@ namespace Kingsland.MofParser.Ast
         public sealed class Builder
         {
 
-            public Builder()
+            public IdentifierToken Instance
             {
+                get;
+                set;
+            }
+
+            public IdentifierToken Of
+            {
+                get;
+                set;
             }
 
             public IdentifierToken TypeName
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken As
             {
                 get;
                 set;
@@ -52,16 +66,22 @@ namespace Kingsland.MofParser.Ast
                 set;
             }
 
+            public StatementEndToken StatementEnd
+            {
+                get;
+                set;
+            }
+
             public InstanceValueDeclarationAst Build()
             {
                 return new InstanceValueDeclarationAst(
-                    this.TypeName,
-                    this.Alias,
-                    this.PropertyValues ?? new PropertyValueListAst(
-                        new ReadOnlyDictionary<string, PropertyValueAst>(
-                            new Dictionary<string, PropertyValueAst>()
-                        )
-                    )
+                    instance: this.Instance,
+                    of: this.Of,
+                    typeName: this.TypeName,
+                    @as: this.As,
+                    alias: this.Alias,
+                    propertyValues: this.PropertyValues,
+                    statementEnd: this.StatementEnd
                 );
             }
 
@@ -72,25 +92,51 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         public InstanceValueDeclarationAst(
+            IdentifierToken instance,
+            IdentifierToken of,
             IdentifierToken typeName,
+            IdentifierToken @as,
             AliasIdentifierToken alias,
-            PropertyValueListAst propertyValues
+            PropertyValueListAst propertyValues,
+            StatementEndToken statementEnd
         )
         {
+            this.Instance = instance ?? throw new ArgumentNullException(nameof(instance));
+            this.Of = of ?? throw new ArgumentNullException(nameof(of));
             this.TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+            this.As = @as;
             this.Alias = alias;
             this.PropertyValues = propertyValues ?? new PropertyValueListAst(
                 new ReadOnlyDictionary<string, PropertyValueAst>(
                     new Dictionary<string, PropertyValueAst>()
                 )
             );
+            this.StatementEnd = statementEnd ?? throw new ArgumentNullException(nameof(statementEnd));
         }
 
         #endregion
 
         #region Properties
 
+        public IdentifierToken Instance
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken Of
+        {
+            get;
+            private set;
+        }
+
         public IdentifierToken TypeName
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken As
         {
             get;
             private set;
@@ -108,13 +154,19 @@ namespace Kingsland.MofParser.Ast
             private set;
         }
 
+        public StatementEndToken StatementEnd
+        {
+            get;
+            private set;
+        }
+
         #endregion
 
         #region Object Overrides
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertInstanceValueDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/IntegerValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/IntegerValueAst.cs
@@ -65,7 +65,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertIntegerValueAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/LiteralValueArrayAst.cs
+++ b/src/Kingsland.MofParser/Ast/LiteralValueArrayAst.cs
@@ -14,7 +14,7 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.6.1 Primitive type value
     ///
-    ///     literalValueArray  = "{" [ literalValue *( "," literalValue ) ] "}"
+    ///     literalValueArray = "{" [ literalValue *( "," literalValue ) ] "}"
     ///
     /// </remarks>
     public sealed class LiteralValueArrayAst : PrimitiveTypeValueAst
@@ -75,7 +75,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertLiteralValueArrayAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/LiteralValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/LiteralValueAst.cs
@@ -9,11 +9,13 @@
     ///
     /// 7.6.1 Primitive type value
     ///
-    ///     literalValue = integerValue / realValue /
-    ///                    stringValue / octetStringValue
+    ///     literalValue = integerValue /
+    ///                    realValue /
     ///                    booleanValue /
     ///                    nullValue /
-    ///                    dateTimeValue
+    ///                    stringValue
+    ///                      ; NOTE stringValue covers octetStringValue and
+    ///                      ; dateTimeValue
     ///
     /// </remarks>
     public abstract class LiteralValueAst : PrimitiveTypeValueAst

--- a/src/Kingsland.MofParser/Ast/MethodDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/MethodDeclarationAst.cs
@@ -24,13 +24,15 @@ namespace Kingsland.MofParser.Ast
     ///                         enumName /
     ///                         classReference
     ///
-    ///     array             = "[" "]"
     ///     methodName        = IDENTIFIER
     ///     classReference    = DT_REFERENCE
     ///     DT_REFERENCE      = className REF
-    ///     REF               = "ref" ; keyword: case insensitive
     ///     VOID              = "void" ; keyword: case insensitive
     ///     parameterList     = parameterDeclaration *( "," parameterDeclaration )
+    ///
+    /// 7.5.5 Property declaration
+    ///
+    ///    array             = "[" "]"
     ///
     public sealed class MethodDeclarationAst : ClassFeatureAst
     {
@@ -151,7 +153,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertMethodDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/MofSpecificationAst.cs
+++ b/src/Kingsland.MofParser/Ast/MofSpecificationAst.cs
@@ -71,7 +71,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertMofSpecificationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/NullValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/NullValueAst.cs
@@ -14,6 +14,7 @@ namespace Kingsland.MofParser.Ast
     /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
     ///
     ///     nullValue = NULL
+    ///
     ///     NULL      = "null" ; keyword: case insensitive
     ///                        ; second
     ///
@@ -66,7 +67,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertNullValueAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/ParameterDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/ParameterDeclarationAst.cs
@@ -22,6 +22,7 @@ namespace Kingsland.MofParser.Ast
     ///     primitiveParamDeclaration = primitiveType parameterName [ array ]
     ///                                 [ "=" primitiveTypeValue
     ///                                 ]
+    ///
     ///     complexParamDeclaration   = structureOrClassName parameterName [ array ]
     ///                                 [ "=" ( complexTypeValue / aliasIdentifier ) ]
     ///
@@ -159,7 +160,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertParameterDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/PropertyDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/PropertyDeclarationAst.cs
@@ -13,10 +13,10 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.5.5 Property declaration
     ///
-    ///     propertyDeclaration = [ qualifierList ] ( primitivePropertyDeclaration /
-    ///                                               complexPropertyDeclaration /
-    ///                                               enumPropertyDeclaration /
-    ///                                               referencePropertyDeclaration) ";"
+    ///     propertyDeclaration          = [ qualifierList ] ( primitivePropertyDeclaration /
+    ///                                    complexPropertyDeclaration /
+    ///                                    enumPropertyDeclaration /
+    ///                                    referencePropertyDeclaration) ";"
     ///
     ///     primitivePropertyDeclaration = primitiveType propertyName [ array ]
     ///                                    [ "=" primitiveTypeValue]
@@ -33,11 +33,11 @@ namespace Kingsland.MofParser.Ast
     ///     array                        = "[" "]"
     ///     propertyName                 = IDENTIFIER
     ///     structureOrClassName         = IDENTIFIER
+    ///
     ///     classReference               = DT_REFERENCE
     ///     DT_REFERENCE                 = className REF
     ///     REF                          = "ref" ; keyword: case insensitive
     ///
-
     public sealed class PropertyDeclarationAst : StructureFeatureAst
     {
 
@@ -114,7 +114,7 @@ namespace Kingsland.MofParser.Ast
             this.PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
             this.IsArray = isArray;
             this.IsRef = isRef;
-            this.Initializer = initializer ?? throw new ArgumentNullException(nameof(initializer));
+            this.Initializer = initializer;
         }
 
         #endregion
@@ -163,7 +163,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertPropertyDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/PropertyValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/PropertyValueAst.cs
@@ -11,7 +11,7 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.5.9 Complex type value
     ///
-    ///     propertyValue = primitiveTypeValue / complexTypeValue / referenceTypeValue / enumTypeValue
+    ///     propertyValue      = primitiveTypeValue / complexTypeValue / referenceTypeValue / enumTypeValue
     ///
     /// 7.6.1 Primitive type value
     ///
@@ -19,7 +19,7 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.5.9 Complex type value
     ///
-    ///     complexTypeValue = complexValue / complexValueArray
+    ///     complexTypeValue   = complexValue / complexValueArray
     ///
     /// 7.6.4 Reference type value
     ///
@@ -27,7 +27,7 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.6.3 Enum type value
     ///
-    ///     enumTypeValue = enumValue / enumValueArray
+    ///     enumTypeValue      = enumValue / enumValueArray
     ///
     /// </remarks>
     public abstract class PropertyValueAst : AstNode

--- a/src/Kingsland.MofParser/Ast/PropertyValueListAst.cs
+++ b/src/Kingsland.MofParser/Ast/PropertyValueListAst.cs
@@ -77,7 +77,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertPropertyValueListAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/QualifierListAst.cs
+++ b/src/Kingsland.MofParser/Ast/QualifierListAst.cs
@@ -15,14 +15,7 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.4.1 QualifierList
     ///
-    ///     qualifierList                 = "[" qualifierValue *( "," qualifierValue ) "]"
-    ///
-    ///     qualifierValue                = qualifierName [ qualifierValueInitializer /
-    ///                                     qualiferValueArrayInitializer ]
-    ///
-    ///     qualifierValueInitializer     = "(" literalValue ")"
-    ///
-    ///     qualiferValueArrayInitializer = "{" literalValue *( "," literalValue ) "}"
+    ///     qualifierList = "[" qualifierValue *( "," qualifierValue ) "]"
     ///
     /// </remarks>
     public sealed class QualifierListAst : AstNode
@@ -35,10 +28,10 @@ namespace Kingsland.MofParser.Ast
 
             public Builder()
             {
-                this.Qualifiers = new List<QualifierTypeDeclarationAst>();
+                this.Qualifiers = new List<QualifierValueAst>();
             }
 
-            public List<QualifierTypeDeclarationAst> Qualifiers
+            public List<QualifierValueAst> Qualifiers
             {
                 get;
                 set;
@@ -47,8 +40,8 @@ namespace Kingsland.MofParser.Ast
             public QualifierListAst Build()
             {
                 return new QualifierListAst(
-                    new ReadOnlyCollection<QualifierTypeDeclarationAst>(
-                        this.Qualifiers ?? new List<QualifierTypeDeclarationAst>()
+                    new ReadOnlyCollection<QualifierValueAst>(
+                        this.Qualifiers ?? new List<QualifierValueAst>()
                     )
                 );
             }
@@ -59,10 +52,10 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public QualifierListAst(ReadOnlyCollection<QualifierTypeDeclarationAst> qualifiers)
+        public QualifierListAst(ReadOnlyCollection<QualifierValueAst> qualifiers)
         {
-            this.Qualifiers = qualifiers ?? new ReadOnlyCollection<QualifierTypeDeclarationAst>(
-                new List<QualifierTypeDeclarationAst>()
+            this.Qualifiers = qualifiers ?? new ReadOnlyCollection<QualifierValueAst>(
+                new List<QualifierValueAst>()
             );
         }
 
@@ -70,7 +63,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public ReadOnlyCollection<QualifierTypeDeclarationAst> Qualifiers
+        public ReadOnlyCollection<QualifierValueAst> Qualifiers
         {
             get;
             private set;
@@ -82,7 +75,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertQualifierListAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/QualifierTypeDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/QualifierTypeDeclarationAst.cs
@@ -17,6 +17,10 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.4 Qualifiers
     ///
+    ///     qualifierTypeDeclaration = [qualifierList] QUALIFIER qualifierName ":"
+    ///                                qualifierType qualifierScope
+    ///                                [qualifierPolicy] ";"
+    ///
     /// </returns>
     public sealed class QualifierTypeDeclarationAst : MofProductionAst
     {
@@ -29,6 +33,12 @@ namespace Kingsland.MofParser.Ast
             public Builder()
             {
                 this.Flavors = new List<string>();
+            }
+
+            public QualifierListAst Qualifiers
+            {
+                get;
+                set;
             }
 
             public IdentifierToken Name
@@ -52,6 +62,7 @@ namespace Kingsland.MofParser.Ast
             public QualifierTypeDeclarationAst Build()
             {
                 return new QualifierTypeDeclarationAst(
+                    this.Qualifiers,
                     this.Name,
                     this.Initializer,
                     new ReadOnlyCollection<string>(
@@ -67,11 +78,13 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         private QualifierTypeDeclarationAst(
+            QualifierListAst qualifiers,
             IdentifierToken name,
             PrimitiveTypeValueAst initializer,
             ReadOnlyCollection<string> flavors
         )
         {
+            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Initializer = initializer ?? throw new ArgumentNullException(nameof(initializer));
             this.Flavors = flavors ?? throw new ArgumentNullException(nameof(flavors));
@@ -80,6 +93,12 @@ namespace Kingsland.MofParser.Ast
         #endregion
 
         #region Properties
+
+        public QualifierListAst Qualifiers
+        {
+            get;
+            private set;
+        }
 
         public IdentifierToken Name
         {
@@ -105,7 +124,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertQualifierTypeDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/QualifierValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/QualifierValueAst.cs
@@ -1,0 +1,141 @@
+﻿using Kingsland.MofParser.CodeGen;
+using Kingsland.MofParser.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Kingsland.MofParser.Ast
+{
+
+    /// <summary>
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <returns></returns>
+    /// <remarks>
+    ///
+    /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
+    ///
+    /// 7.4.1 QualifierList
+    ///
+    ///     qualifierValue                = qualifierName [ qualifierValueInitializer /
+    ///                                     qualiferValueArrayInitializer ]
+    ///
+    ///     qualifierValueInitializer     = "(" literalValue ")"
+    ///
+    ///     qualiferValueArrayInitializer = "{" literalValue *( "," literalValue ) "}"
+    ///
+    /// </remarks>
+    public sealed class QualifierValueAst : AstNode
+    {
+
+        #region Builder
+
+        public sealed class Builder
+        {
+
+            public IdentifierToken QualifierName
+            {
+                get;
+                set;
+            }
+
+            public LiteralValueAst ValueInitializer
+            {
+                get;
+                set;
+            }
+
+            public LiteralValueArrayAst ValueArrayInitializer
+            {
+                get;
+                set;
+            }
+
+            public List<IdentifierToken> Flavors
+            {
+                get;
+                set;
+            }
+
+            public QualifierValueAst Build()
+            {
+                return new QualifierValueAst(
+                    this.QualifierName,
+                    this.ValueInitializer,
+                    this.ValueArrayInitializer,
+                    new ReadOnlyCollection<IdentifierToken>(
+                        this.Flavors ?? new List<IdentifierToken>()
+                    )
+                );
+            }
+
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public QualifierValueAst(IdentifierToken qualifierName, LiteralValueAst valueInitializer, LiteralValueArrayAst valueArrayInitializer, ReadOnlyCollection<IdentifierToken> flavors)
+        {
+            this.QualifierName = qualifierName ?? throw new ArgumentNullException(nameof(qualifierName));
+            this.ValueInitializer = valueInitializer;
+            this.ValueArrayInitializer = valueArrayInitializer;
+            this.Flavors = flavors ?? new ReadOnlyCollection<IdentifierToken>(
+                new List<IdentifierToken>()
+            );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public IdentifierToken QualifierName
+        {
+            get;
+            private set;
+        }
+
+        public LiteralValueAst ValueInitializer
+        {
+            get;
+            private set;
+        }
+
+        public LiteralValueArrayAst ValueArrayInitializer
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <remarks>
+        ///
+        /// 7.4 Qualifiers
+        ///
+        /// NOTE A MOF v2 qualifier declaration has to be converted to MOF v3 qualifierTypeDeclaration because the
+        /// MOF v2 qualifier flavor has been replaced by the MOF v3 qualifierPolicy.
+        ///
+        /// These aren't part of the MOF 3.0.1 spec, but we'll include them anyway for backward compatibility.
+        ///
+        /// </remarks>
+        public ReadOnlyCollection<IdentifierToken> Flavors
+        {
+            get;
+            private set;
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return MofGenerator.ConvertQualifierValueAst(this);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Ast/RealValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/RealValueAst.cs
@@ -67,7 +67,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertRealValueAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/ReferenceTypeValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/ReferenceTypeValueAst.cs
@@ -11,16 +11,21 @@ namespace Kingsland.MofParser.Ast
     ///
     /// 7.6.4 Reference type value
     ///
-    ///     referenceTypeValue  = referenceValue / referenceValueArray
-    ///     referenceValueArray = "{" [ objectPathValue *( "," objectPathValue ) ]
+    /// Whitespace as defined in 5.2 is allowed between the elements of the rules in this ABNF section.
     ///
+    ///     referenceTypeValue   = objectPathValue / objectPathValueArray
+    ///     objectPathValueArray = "{" [ objectPathValue *( "," objectPathValue ) ]
+    ///                            "}"
     /// No whitespace is allowed between the elements of the rules in this ABNF section.
     ///
-    ///     objectPathValue = [namespacePath ":"] instanceId
-    ///     namespacePath   = [serverPath] namespaceName
+    ///     ; Note: objectPathValues are URLs and shall conform to RFC 3986 (Uniform
+    ///     ; Resource Identifiers(URI): Generic Syntax) and to the following ABNF.
     ///
-    /// ; Note: The production rules for host and port are defined in IETF
-    /// ; RFC 3986 (Uniform Resource Identifiers (URI): Generic Syntax).
+    ///     objectPathValue  = [namespacePath ":"] instanceId
+    ///     namespacePath    = [serverPath] namespaceName
+    ///
+    ///     ; Note: The production rules for host and port are defined in IETF
+    ///     ; RFC 3986 (Uniform Resource Identifiers (URI): Generic Syntax).
     ///
     ///     serverPath       = (host / LOCALHOST) [ ":" port] "/"
     ///     LOCALHOST        = "localhost" ; Case insensitive

--- a/src/Kingsland.MofParser/Ast/StringValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/StringValueAst.cs
@@ -99,7 +99,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertStringValueAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/StructureValueDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/StructureValueDeclarationAst.cs
@@ -112,7 +112,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertToMof(this);
+            return MofGenerator.ConvertStructureValueDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/AstNodeDiagram.cd
+++ b/src/Kingsland.MofParser/AstNodeDiagram.cd
@@ -16,6 +16,13 @@
   </Class>
   <Class Name="Kingsland.MofParser.Ast.LiteralValueArrayAst" Collapsed="true">
     <Position X="5.75" Y="4.25" Width="1.5" />
+    <NestedTypes>
+      <Class Name="Kingsland.MofParser.Ast.LiteralValueArrayAst.Builder" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>Ast\LiteralValueArrayAst.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAgAAAAAAA=</HashCode>
       <FileName>Ast\LiteralValueArrayAst.cs</FileName>
@@ -57,28 +64,13 @@
       <FileName>Ast\PropertyValueAst.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Kingsland.MofParser.Ast.ReferenceTypeValueAst" Collapsed="true">
-    <Position X="11.75" Y="3" Width="1.5" />
-    <InheritanceLine Type="Kingsland.MofParser.Ast.PropertyValueAst" FixedToPoint="true">
-      <Path>
-        <Point X="11.25" Y="2.441" />
-        <Point X="11.25" Y="2.7" />
-        <Point X="12.5" Y="2.7" />
-        <Point X="12.5" Y="3" />
-      </Path>
-    </InheritanceLine>
-    <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAEAAAAAAQAAAAAAAAAAAAAAAAAAAA=</HashCode>
-      <FileName>Ast\ReferenceTypeValueAst.cs</FileName>
-    </TypeIdentifier>
-  </Class>
   <Class Name="Kingsland.MofParser.Ast.BooleanValueAst" Collapsed="true">
-    <Position X="8.75" Y="5.25" Width="1.5" />
+    <Position X="8.75" Y="7.25" Width="1.5" />
     <InheritanceLine Type="Kingsland.MofParser.Ast.LiteralValueAst" FixedToPoint="true">
       <Path>
         <Point X="8.5" Y="4.941" />
-        <Point X="8.5" Y="5.687" />
-        <Point X="8.75" Y="5.687" />
+        <Point X="8.5" Y="7.687" />
+        <Point X="8.75" Y="7.687" />
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
@@ -101,12 +93,12 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Kingsland.MofParser.Ast.IntegerValueAst" Collapsed="true">
-    <Position X="8.75" Y="6.25" Width="1.5" />
+    <Position X="8.75" Y="5.25" Width="1.5" />
     <InheritanceLine Type="Kingsland.MofParser.Ast.LiteralValueAst" FixedToPoint="true">
       <Path>
         <Point X="8.5" Y="4.941" />
-        <Point X="8.5" Y="6.625" />
-        <Point X="8.75" Y="6.625" />
+        <Point X="8.5" Y="5.625" />
+        <Point X="8.75" Y="5.625" />
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
@@ -145,12 +137,12 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Kingsland.MofParser.Ast.RealValueAst" Collapsed="true">
-    <Position X="8.75" Y="8.25" Width="1.5" />
+    <Position X="8.75" Y="6.25" Width="1.5" />
     <InheritanceLine Type="Kingsland.MofParser.Ast.LiteralValueAst" FixedToPoint="true">
       <Path>
         <Point X="8.5" Y="4.941" />
-        <Point X="8.5" Y="8.562" />
-        <Point X="8.75" Y="8.562" />
+        <Point X="8.5" Y="6.562" />
+        <Point X="8.75" Y="6.562" />
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
@@ -173,12 +165,12 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Kingsland.MofParser.Ast.NullValueAst" Collapsed="true">
-    <Position X="8.75" Y="7.25" Width="1.5" />
+    <Position X="8.75" Y="8.25" Width="1.5" />
     <InheritanceLine Type="Kingsland.MofParser.Ast.LiteralValueAst" FixedToPoint="true">
       <Path>
         <Point X="8.5" Y="4.941" />
-        <Point X="8.5" Y="7.625" />
-        <Point X="8.75" Y="7.625" />
+        <Point X="8.5" Y="8.625" />
+        <Point X="8.75" Y="8.625" />
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
@@ -310,7 +302,7 @@
     </InheritanceLine>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAEAAAAABQAAAAAAAAAAAAAAAAABAA=</HashCode>
-      <FileName>Ast\QualifierDeclarationAst.cs</FileName>
+      <FileName>Ast\QualifierTypeDeclarationAst.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Font Name="Segoe UI" Size="9" />

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -19,49 +19,77 @@ namespace Kingsland.MofParser.CodeGen
             {
                 return null;
             }
-            // 7.2 MOF specification
-            if (node is MofSpecificationAst) { return MofGenerator.ConvertToMof((MofSpecificationAst)node, quirks); }
-            // 7.3 Compiler directives
-            if (node is CompilerDirectiveAst) { return MofGenerator.ConvertToMof((CompilerDirectiveAst)node, quirks); }
-            // 7.4 Qualifiers
-            if (node is QualifierTypeDeclarationAst) { return MofGenerator.ConvertToMof((QualifierTypeDeclarationAst)node, quirks); }
-            // 7.4.1 QualifierList
-            if (node is QualifierListAst) { return MofGenerator.ConvertToMof((QualifierListAst)node, quirks); }
-            // 7.5.2 Class declaration
-            if (node is ClassDeclarationAst) { return MofGenerator.ConvertToMof((ClassDeclarationAst)node, quirks); }
-            // 7.5.5 Property declaration
-            if (node is PropertyDeclarationAst) { return MofGenerator.ConvertToMof((PropertyDeclarationAst)node, quirks); }
-            // 7.5.6 Method declaration
-            if (node is MethodDeclarationAst) { return MofGenerator.ConvertToMof((MethodDeclarationAst)node, quirks); }
-            // 7.5.7 Parameter declaration
-            if (node is ParameterDeclarationAst) { return MofGenerator.ConvertToMof((ParameterDeclarationAst)node, quirks); }
-            // 7.5.9 Complex type value
-            if (node is ComplexValueArrayAst) { return MofGenerator.ConvertToMof((ComplexValueArrayAst)node, quirks); }
-            if (node is ComplexValueAst) { return MofGenerator.ConvertToMof((ComplexValueAst)node, quirks); }
-            if (node is PropertyValueAst) { return MofGenerator.ConvertToMof((PropertyValueAst)node, quirks); }
-            // 7.6.1 Primitive type value
-            if (node is LiteralValueArrayAst) { return MofGenerator.ConvertToMof((LiteralValueArrayAst)node, quirks); }
-            // 7.6.1.1 Integer value
-            if (node is IntegerValueAst) { return MofGenerator.ConvertToMof((IntegerValueAst)node, quirks); }
-            // 7.6.1.2 Real value
-            if (node is RealValueAst) { return MofGenerator.ConvertToMof((RealValueAst)node, quirks); }
-            // 7.6.1.3 String values
-            if (node is StringValueAst) { return MofGenerator.ConvertToMof((StringValueAst)node, quirks); }
-            // 7.6.1.5 Boolean value
-            if (node is BooleanValueAst) { return MofGenerator.ConvertToMof((BooleanValueAst)node, quirks); }
-            // 7.6.1.6 Null value
-            if (node is NullValueAst) { return MofGenerator.ConvertToMof((NullValueAst)node, quirks); }
-            // 7.6.4 Reference type value
-            if (node is ReferenceTypeValueAst) { return MofGenerator.ConvertToMof((ReferenceTypeValueAst)node, quirks); }
-            // unknown
-            throw new InvalidOperationException(node.GetType().FullName);
+            switch (node)
+            {
+                case MofSpecificationAst ast:
+                    // 7.2 MOF specification
+                    return MofGenerator.ConvertMofSpecificationAst(ast, quirks);
+                case CompilerDirectiveAst ast:
+                    // 7.3 Compiler directives
+                    return MofGenerator.ConvertCompilerDirectiveAst(ast, quirks);
+                case QualifierTypeDeclarationAst ast:
+                    // 7.4 Qualifiers
+                    return MofGenerator.ConvertQualifierTypeDeclarationAst(ast, quirks);
+                case QualifierListAst ast:
+                    // 7.4.1 QualifierList
+                    return MofGenerator.ConvertQualifierListAst(ast, quirks);
+                case ClassDeclarationAst ast:
+                    // 7.5.2 Class declaration
+                    return MofGenerator.ConvertClassDeclarationAst(ast, quirks);
+                case PropertyDeclarationAst ast:
+                    // 7.5.5 Property declaration
+                    return MofGenerator.ConvertPropertyDeclarationAst(ast, quirks);
+                case MethodDeclarationAst ast:
+                    // 7.5.6 Method declaration
+                    return MofGenerator.ConvertMethodDeclarationAst(ast, quirks);
+                case ParameterDeclarationAst ast:
+                    // 7.5.7 Parameter declaration
+                    return MofGenerator.ConvertParameterDeclarationAst(ast, quirks);
+                case ComplexValueArrayAst ast:
+                    // 7.5.9 Complex type value
+                    return MofGenerator.ConvertComplexValueArrayAst(ast, quirks);
+                case ComplexValueAst ast:
+                    // 7.5.9 Complex type value
+                    return MofGenerator.ConvertComplexValueAst(ast, quirks);
+                case PropertyValueListAst ast:
+                    // 7.5.9 Complex type value
+                    return MofGenerator.ConvertPropertyValueListAst(ast, quirks);
+                case LiteralValueArrayAst ast:
+                    // 7.6.1 Primitive type value
+                    return MofGenerator.ConvertLiteralValueArrayAst(ast, quirks);
+                case IntegerValueAst ast:
+                    // 7.6.1.1 Integer value
+                    return MofGenerator.ConvertIntegerValueAst(ast, quirks);
+                case RealValueAst ast:
+                    // 7.6.1.2 Real value
+                    return MofGenerator.ConvertRealValueAst(ast, quirks);
+                case StringValueAst ast:
+                    // 7.6.1.3 String values
+                    return MofGenerator.ConvertStringValueAst(ast, quirks);
+                case BooleanValueAst ast:
+                    // 7.6.1.5 Boolean value
+                    return MofGenerator.ConvertBooleanValueAst(ast, quirks);
+                case NullValueAst ast:
+                    // 7.6.1.6 Null value
+                    return MofGenerator.ConvertNullValueAst(ast, quirks);
+                case InstanceValueDeclarationAst ast:
+                    // 7.6.2 Complex type value
+                    return MofGenerator.ConvertInstanceValueDeclarationAst(ast, quirks);
+                case StructureValueDeclarationAst ast:
+                    // 7.6.2 Complex type value
+                    return MofGenerator.ConvertStructureValueDeclarationAst(ast, quirks);
+                default:
+                    // unknown
+                    throw new InvalidOperationException(node.GetType().FullName);
+            }
+
         }
 
         #endregion
 
         #region 7.2 MOF specification
 
-        public static string ConvertToMof(MofSpecificationAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertMofSpecificationAst(MofSpecificationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
             for (var i = 0; i < node.Productions.Count; i++)
@@ -70,25 +98,47 @@ namespace Kingsland.MofParser.CodeGen
                 {
                     source.AppendLine();
                 }
-                source.Append(MofGenerator.ConvertToMof(node.Productions[i], quirks));
+                source.Append(MofGenerator.ConvertMofProductionAst(node.Productions[i], quirks));
             }
             return source.ToString();
+        }
+
+        public static string ConvertMofProductionAst(MofProductionAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                case CompilerDirectiveAst ast:
+                    return MofGenerator.ConvertCompilerDirectiveAst(ast, quirks);
+                //case StructureDeclarationAst ast:
+                case ClassDeclarationAst ast:
+                    return MofGenerator.ConvertClassDeclarationAst(ast, quirks);
+                //case AssociationDeclarationAst ast:
+                //case EnumerationDeclarationAst ast:
+                case InstanceValueDeclarationAst ast:
+                    return MofGenerator.ConvertInstanceValueDeclarationAst(ast, quirks);
+                case StructureValueDeclarationAst ast:
+                    return MofGenerator.ConvertStructureValueDeclarationAst(ast, quirks);
+                case QualifierTypeDeclarationAst ast:
+                    return MofGenerator.ConvertQualifierTypeDeclarationAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         #endregion
 
         #region 7.3 Compiler directives
 
-        public static string ConvertToMof(CompilerDirectiveAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertCompilerDirectiveAst(CompilerDirectiveAst node, MofQuirks quirks = MofQuirks.None)
         {
             return string.Format("!!!!!{0}!!!!!", node.GetType().Name);
         }
 
-        #endregion
+    #endregion
 
         #region 7.4 Qualifiers
 
-        public static string ConvertToMof(QualifierTypeDeclarationAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertQualifierTypeDeclarationAst(QualifierTypeDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
             if (!string.IsNullOrEmpty(node.Name.Name))
@@ -99,11 +149,11 @@ namespace Kingsland.MofParser.CodeGen
             {
                 if (node.Initializer is LiteralValueAst)
                 {
-                    source.AppendFormat("({0})", MofGenerator.ConvertToMof(node.Initializer, quirks));
+                    source.AppendFormat("({0})", MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
                 }
                 else if (node.Initializer is LiteralValueArrayAst)
                 {
-                    source.Append(MofGenerator.ConvertToMof(node.Initializer, quirks));
+                    source.Append(MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
                 }
                 else
                 {
@@ -121,15 +171,19 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.4.1 QualifierList
 
-        public static string ConvertToMof(QualifierListAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertQualifierListAst(QualifierListAst node, MofQuirks quirks = MofQuirks.None)
         {
+
+            // [Abstract, OCL]
+
             var source = new StringBuilder();
             var lastQualifierName = default(string);
+
             source.Append("[");
             for (var i = 0; i < node.Qualifiers.Count; i++)
             {
                 var thisQualifier = node.Qualifiers[i];
-                var thisQualifierName = node.Qualifiers[i].Name.GetNormalizedName();
+                var thisQualifierName = thisQualifier.QualifierName.GetNormalizedName();
                 if (i > 0)
                 {
                     source.Append(",");
@@ -139,23 +193,78 @@ namespace Kingsland.MofParser.CodeGen
                         source.Append(" ");
                     }
                 }
-                source.Append(MofGenerator.ConvertToMof(thisQualifier, quirks));
+                source.Append(MofGenerator.ConvertQualifierValueAst(thisQualifier, quirks));
                 lastQualifierName = thisQualifierName;
             }
             source.Append("]");
             return source.ToString();
         }
 
+        public static string ConvertQualifierValueAst(QualifierValueAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            // Abstract
+            // Description("an instance of a class that derives from the GOLF_Base class. ")
+            // OCL{"-- the key property cannot be NULL", "inv: InstanceId.size() = 10"}
+            var source = new StringBuilder();
+            source.Append(node.QualifierName.Extent.Text);
+            if (node.ValueInitializer != null)
+            {
+                source.Append("(");
+                source.Append(MofGenerator.ConvertLiteralValueAst(node.ValueInitializer));
+                source.Append(")");
+            }
+            else if (node.ValueArrayInitializer != null)
+            {
+                source.Append(MofGenerator.ConvertLiteralValueArrayAst(node.ValueArrayInitializer));
+            }
+            ///
+            /// 7.4 Qualifiers
+            ///
+            /// NOTE A MOF v2 qualifier declaration has to be converted to MOF v3 qualifierTypeDeclaration because the
+            /// MOF v2 qualifier flavor has been replaced by the MOF v3 qualifierPolicy.
+            ///
+            /// These aren't part of the MOF 3.0.1 spec, but we'll include them anyway for backward compatibility.
+            ///
+            if (node.Flavors.Count > 0)
+            {
+                source.Append(": ");
+                source.Append(
+                    string.Join(
+                        " ",
+                        node.Flavors.Select(f => f.Name)
+                    )
+                );
+            }
+            return source.ToString();
+        }
+
+        #endregion
+
+        #region 7.5.1 Structure declaration
+
+        public static string ConvertStructureFeatureAst(StructureFeatureAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                //case StructureDeclarationAst ast:
+                //case EnumerationDeclarationAst ast:
+                case PropertyDeclarationAst ast:
+                    return MofGenerator.ConvertPropertyDeclarationAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         #endregion
 
         #region 7.5.2 Class declaration
 
-        public static string ConvertToMof(ClassDeclarationAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertClassDeclarationAst(ClassDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
             if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendLine(MofGenerator.ConvertToMof(node.Qualifiers, quirks));
+                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
             }
             if (node.Superclass == null)
             {
@@ -168,22 +277,35 @@ namespace Kingsland.MofParser.CodeGen
             source.AppendLine("{");
             foreach (var feature in node.Features)
             {
-                source.AppendFormat("\t{0}\r\n", MofGenerator.ConvertToMof(feature, quirks));
+                source.AppendFormat("\t{0}\r\n", MofGenerator.ConvertClassFeatureAst(feature, quirks));
             }
-            source.AppendLine("};");
+            source.Append("};");
             return source.ToString();
+        }
+
+        public static string ConvertClassFeatureAst(ClassFeatureAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                case StructureFeatureAst ast:
+                    return MofGenerator.ConvertStructureFeatureAst(ast, quirks);
+                case MethodDeclarationAst ast:
+                    return MofGenerator.ConvertMethodDeclarationAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         #endregion
 
         #region 7.5.5 Property declaration
 
-        public static string ConvertToMof(PropertyDeclarationAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertPropertyDeclarationAst(PropertyDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
             if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendFormat("{0} ", MofGenerator.ConvertToMof(node.Qualifiers, quirks));
+                source.AppendFormat("{0} ", MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
             }
             source.AppendFormat("{0} ", node.ReturnType.Name);
             if (node.IsRef)
@@ -197,7 +319,7 @@ namespace Kingsland.MofParser.CodeGen
             }
             if (node.Initializer != null)
             {
-                source.AppendFormat(" = {0}", MofGenerator.ConvertToMof(node.Initializer, quirks));
+                source.AppendFormat(" = {0}", MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
             }
             source.Append(";");
             return source.ToString();
@@ -207,12 +329,12 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.5.6 Method declaration
 
-        public static string ConvertToMof(MethodDeclarationAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertMethodDeclarationAst(MethodDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
             if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendFormat("{0}", MofGenerator.ConvertToMof(node.Qualifiers, quirks));
+                source.AppendFormat("{0}", MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
             }
             var quirkEnabled = (quirks & MofQuirks.PrefixSpaceBeforeQualifierlessMethodDeclarations) == MofQuirks.PrefixSpaceBeforeQualifierlessMethodDeclarations;
             if (quirkEnabled || ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0))
@@ -226,7 +348,7 @@ namespace Kingsland.MofParser.CodeGen
             }
             else
             {
-                var values = node.Parameters.Select(p => MofGenerator.ConvertToMof(p, quirks)).ToArray();
+                var values = node.Parameters.Select(p => MofGenerator.ConvertParameterDeclarationAst(p, quirks)).ToArray();
                 source.AppendFormat("({0});", string.Join(", ", values));
             }
             return source.ToString();
@@ -236,12 +358,12 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.5.7 Parameter declaration
 
-        public static string ConvertToMof(ParameterDeclarationAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertParameterDeclarationAst(ParameterDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
             if (node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendFormat("{0} ", MofGenerator.ConvertToMof(node.Qualifiers, quirks));
+                source.AppendFormat("{0} ", MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
             }
             source.AppendFormat("{0} ", node.Type.Name);
             if (node.IsRef)
@@ -264,28 +386,99 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.5.9 Complex type value
 
-        public static string ConvertToMof(ComplexValueArrayAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertComplexTypeValueAst(ComplexTypeValueAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                case ComplexValueArrayAst ast:
+                    return MofGenerator.ConvertComplexValueArrayAst(ast, quirks);
+                case ComplexValueAst ast:
+                    return MofGenerator.ConvertComplexValueAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+
+        public static string ConvertComplexValueArrayAst(ComplexValueArrayAst node, MofQuirks quirks = MofQuirks.None)
         {
             return string.Format("{{{0}}}", string.Join(", ", node.Values.Select(v => v.ToString()).ToArray()));
         }
 
-        public static string ConvertToMof(ComplexValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertComplexValueAst(ComplexValueAst node, MofQuirks quirks = MofQuirks.None)
         {
             return string.Format("!!!!!{0}!!!!!", node.GetType().Name);
         }
 
-        public static string ConvertToMof(PropertyValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertPropertyValueListAst(PropertyValueListAst node, MofQuirks quirks = MofQuirks.None)
         {
-            return string.Format("!!!!!{0}!!!!!", node.GetType().Name);
+            // {
+            //     Reference = TRUE;
+            // }
+            var source = new StringBuilder();
+            source.AppendLine("{");
+            foreach (var propertyValue in node.PropertyValues)
+            {
+                source.AppendLine($"    {propertyValue.Key} = {MofGenerator.ConvertPropertyValueAst(propertyValue.Value)};");
+            }
+            source.Append("}");
+            return source.ToString();
+        }
+
+        public static string ConvertPropertyValueAst(PropertyValueAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                case PrimitiveTypeValueAst ast:
+                    return MofGenerator.ConvertPrimitiveTypeValueAst(ast, quirks);
+                case ComplexTypeValueAst ast:
+                    return MofGenerator.ConvertComplexTypeValueAst(ast, quirks);
+                //case ReferenceTypeValueAst ast:
+                //case EnumTypeValueAst ast:
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         #endregion
 
         #region 7.6.1 Primitive type value
 
-        public static string ConvertToMof(LiteralValueArrayAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertPrimitiveTypeValueAst(PrimitiveTypeValueAst node, MofQuirks quirks = MofQuirks.None)
         {
-            var values = node.Values.Select(v => MofGenerator.ConvertToMof(v, quirks)).ToArray();
+            switch (node)
+            {
+                case LiteralValueAst ast:
+                    return MofGenerator.ConvertLiteralValueAst(ast, quirks);
+                case LiteralValueArrayAst ast:
+                    return MofGenerator.ConvertLiteralValueArrayAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        public static string ConvertLiteralValueAst(LiteralValueAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                case IntegerValueAst ast:
+                    return MofGenerator.ConvertIntegerValueAst(ast, quirks);
+                case RealValueAst ast:
+                    return MofGenerator.ConvertRealValueAst(ast, quirks);
+                case BooleanValueAst ast:
+                    return MofGenerator.ConvertBooleanValueAst(ast, quirks);
+                case NullValueAst ast:
+                    return MofGenerator.ConvertNullValueAst(ast, quirks);
+                case StringValueAst ast:
+                    return MofGenerator.ConvertStringValueAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        public static string ConvertLiteralValueArrayAst(LiteralValueArrayAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            var values = node.Values.Select(v => MofGenerator.ConvertLiteralValueAst(v, quirks)).ToArray();
             return string.Format("{{{0}}}", string.Join(", ", values));
         }
 
@@ -293,7 +486,7 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.6.1.1 Integer value
 
-        public static string ConvertToMof(IntegerValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertIntegerValueAst(IntegerValueAst node, MofQuirks quirks = MofQuirks.None)
         {
             return node.Value.ToString();
         }
@@ -302,7 +495,7 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.6.1.2 Real value
 
-        public static string ConvertToMof(RealValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertRealValueAst(RealValueAst node, MofQuirks quirks = MofQuirks.None)
         {
             return node.Value.ToString();
         }
@@ -311,7 +504,7 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.6.1.3 String values
 
-        public static string ConvertToMof(StringValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertStringValueAst(StringValueAst node, MofQuirks quirks = MofQuirks.None)
         {
             return string.Format("\"{0}\"", MofGenerator.EscapeString(node.Value));
         }
@@ -349,7 +542,7 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.6.1.5 Boolean value
 
-        public static string ConvertToMof(BooleanValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertBooleanValueAst(BooleanValueAst node, MofQuirks quirks = MofQuirks.None)
         {
             return node.Token.Extent.Text;
         }
@@ -358,22 +551,52 @@ namespace Kingsland.MofParser.CodeGen
 
         #region 7.6.1.6 Null value
 
-        public static string ConvertToMof(NullValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertNullValueAst(NullValueAst node, MofQuirks quirks = MofQuirks.None)
         {
             return node.Token.Extent.Text;
         }
 
         #endregion
 
-        #region 7.6.4 Reference type value
+        #region 7.6.2 Complex type value
 
-        public static string ConvertToMof(ReferenceTypeValueAst node, MofQuirks quirks = MofQuirks.None)
+        public static string ConvertInstanceValueDeclarationAst(InstanceValueDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
-            return string.Format("!!!!!{0}!!!!!", node.GetType().Name);
+            // instance of myType as $Alias00000070
+            // {
+            //     Reference = TRUE;
+            // };
+            var source = new StringBuilder();
+            // instance of myType as $Alias00000070
+            source.Append(node.Instance.Extent.Text);
+            source.Append(' ');
+            source.Append(node.Of.Extent.Text);
+            source.Append(' ');
+            source.Append(node.TypeName.Name);
+            if (node.Alias != null)
+            {
+                source.Append(' ');
+                source.Append(node.As.Extent.Text);
+                source.Append(' ');
+                source.Append($"${node.Alias.Name}");
+            }
+            source.AppendLine();
+            // {
+            //     Reference = TRUE;
+            // }
+            source.Append(MofGenerator.ConvertPropertyValueListAst(node.PropertyValues));
+            // ;
+            source.Append(node.StatementEnd.Extent.Text);
+            return source.ToString();
+        }
+
+        public static string ConvertStructureValueDeclarationAst(StructureValueDeclarationAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            throw new NotImplementedException();
         }
 
         #endregion
 
-    }
+        }
 
 }

--- a/src/Kingsland.MofParser/Kingsland.MofParser.csproj
+++ b/src/Kingsland.MofParser/Kingsland.MofParser.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Source\UnexpectedEndOfStreamException.cs" />
     <Compile Include="Tokens\AttributeCloseToken.cs" />
     <Compile Include="Tokens\AttributeOpenToken.cs" />
+    <Compile Include="Tokens\RealLiteralToken.cs" />
     <Compile Include="Tokens\NullLiteralToken.cs" />
     <Compile Include="Tokens\ParenthesesCloseToken.cs" />
     <Compile Include="Tokens\ColonToken.cs" />

--- a/src/Kingsland.MofParser/Kingsland.MofParser.csproj
+++ b/src/Kingsland.MofParser/Kingsland.MofParser.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Ast\ClassDeclarationAst.cs" />
     <Compile Include="Ast\ComplexTypeValueAst.cs" />
     <Compile Include="Ast\PropertyValueListAst.cs" />
+    <Compile Include="Ast\QualifierValueAst.cs" />
     <Compile Include="Ast\StructureFeatureAst.cs" />
     <Compile Include="Ast\StructureValueDeclarationAst.cs" />
     <Compile Include="Ast\InstanceValueDeclarationAst.cs" />
@@ -48,7 +49,7 @@
     <Compile Include="Ast\MethodDeclarationAst.cs" />
     <Compile Include="Ast\NullValueAst.cs" />
     <Compile Include="Ast\CompilerDirectiveAst.cs" />
-    <Compile Include="Ast\QualifierDeclarationAst.cs" />
+    <Compile Include="Ast\QualifierTypeDeclarationAst.cs" />
     <Compile Include="Ast\QualifierListAst.cs" />
     <Compile Include="Ast\RealValueAst.cs" />
     <Compile Include="Ast\StringValueAst.cs" />
@@ -57,7 +58,6 @@
     <Compile Include="Ast\MofProductionAst.cs" />
     <Compile Include="Ast\PrimitiveTypeValueAst.cs" />
     <Compile Include="Ast\PropertyValueAst.cs" />
-    <Compile Include="Ast\ReferenceTypeValueAst.cs" />
     <Compile Include="CodeGen\MofGenerator.cs" />
     <Compile Include="CodeGen\MofQuirks.cs" />
     <Compile Include="Lexing\LexerEngine.cs" />

--- a/src/Kingsland.MofParser/Objects/Instance.cs
+++ b/src/Kingsland.MofParser/Objects/Instance.cs
@@ -64,10 +64,6 @@ namespace Kingsland.MofParser.Objects
                 {
                     instance.Properties.Add(property.Key, Instance.GetLiteralValue((LiteralValueAst)propertyValue));
                 }
-                else if ((propertyValue as ReferenceTypeValueAst) != null)
-                {
-                    instance.Properties.Add(property.Key, (((ReferenceTypeValueAst)propertyValue).Name));
-                }
                 else
                 {
                     throw new InvalidOperationException();

--- a/src/Kingsland.MofParser/Parsing/StringValidator.cs
+++ b/src/Kingsland.MofParser/Parsing/StringValidator.cs
@@ -33,7 +33,7 @@ namespace Kingsland.MofParser.Parsing
 
         #endregion
 
-        #region A.4 Structure declaration
+        #region 7.5.1 Structure declaration
 
         #region structureName = elementName
 
@@ -52,7 +52,7 @@ namespace Kingsland.MofParser.Parsing
 
         #endregion
 
-        #region A.5 Class declaration
+        #region 7.5.2 Class declaration
 
         #region className = elementName
 
@@ -71,7 +71,7 @@ namespace Kingsland.MofParser.Parsing
 
         #endregion
 
-        #region A.6 Association declaration
+        #region 7.5.3 Association declaration
 
         #region associationName = elementName
 
@@ -90,7 +90,187 @@ namespace Kingsland.MofParser.Parsing
 
         #endregion
 
-        #region A.13 Names
+        #region 7.6.1.1 Integer value
+
+        #region binaryDigit = "0" / "1"
+
+        public static bool IsBinaryDigit(char value)
+        {
+            return (value >= '0') && (value <= '1');
+        }
+
+        #endregion
+
+        #region octalDigit = "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7"
+
+        public static bool IsOctalDigit(char value)
+        {
+            return (value >= '0') && (value <= '7');
+        }
+
+        #endregion
+
+        #region hexDigit = decimalDigit / "a" / "A" / "b" / "B" / "c" / "C" / "d" / "D" / "e" / "E" / "f" / "F"
+
+        public static bool IsHexDigit(char value)
+        {
+            return StringValidator.IsDecimalDigit(value) ||
+                   ((value >= 'a') && (value <= 'f')) ||
+                   ((value >= 'A') && (value <= 'F'));
+        }
+
+        #endregion
+
+        #region decimalValue = [ "+" / "-" ] unsignedDecimalValue
+
+        public static bool IsDecimalValue(string value)
+        {
+            if (string.IsNullOrEmpty(value)) { return false; }
+            var chars = value.AsEnumerable();
+            if (new[] { '+', '-' }.Contains(chars.First()))
+            {
+                chars = chars.Skip(1);
+            }
+            return StringValidator.IsPositiveDecimalDigit(chars.First()) &&
+                   chars.Skip(1).All(StringValidator.IsDecimalDigit);
+        }
+
+        #endregion
+
+        #region  unsignedDecimalValue = positiveDecimalDigit *decimalDigit
+
+        public static bool IsUnsignedDecimalValue(string value)
+        {
+            if (string.IsNullOrEmpty(value)) { return false; }
+            return StringValidator.IsPositiveDecimalDigit(value.First()) &&
+                   value.Skip(1).All(StringValidator.IsDecimalDigit);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region 7.6.1.2 Real value
+
+        // realValue = ["+" / "-"] * decimalDigit "." 1*decimalDigit
+        //             [ ("e" / "E") [ "+" / "-" ] 1*decimalDigit ]
+
+        #region decimalDigit = "0" / positiveDecimalDigit
+
+        public static bool IsDecimalDigit(char value)
+        {
+            return (value == '0') || StringValidator.IsPositiveDecimalDigit(value);
+        }
+
+        #endregion
+
+        #region positiveDecimalDigit = "1"..."9"
+
+        public static bool IsPositiveDecimalDigit(char value)
+        {
+            return (value >= '1') && (value <= '9');
+        }
+
+        #endregion
+
+        #endregion
+
+        #region 7.6.1.3 String values
+
+        // The following special characters are used in other ABNF rules in this specification:
+
+        #region BACKSLASH = U+005C ; \
+
+        public static bool IsBackslash(char @char)
+        {
+            return (@char == Constants.BACKSLASH);
+        }
+
+        #endregion
+
+        #region DOUBLEQUOTE = U+0022 ; "
+
+        public static bool IsDoubleQuote(char @char)
+        {
+            return (@char == Constants.DOUBLEQUOTE);
+        }
+
+        #endregion
+
+        #region SINGLEQUOTE = U+0027 ; '
+
+        public static bool IsSingleQuote(char @char)
+        {
+            return (@char == Constants.SINGLEQUOTE);
+        }
+
+        #endregion
+
+        #region UPPERALPHA = U+0041...U+005A ; A ... Z
+
+        public static bool IsUpperAlpha(char @char)
+        {
+            return (@char >= '\u0041') && (@char <= '\u005A');
+        }
+
+        #endregion
+
+        #region LOWERALPHA = U+0061...U+007A ; a ... z
+
+        public static bool IsLowerAlpha(char @char)
+        {
+            return (@char >= '\u0061') && (@char <= '\u007A');
+        }
+
+        #endregion
+
+        #region UNDERSCORE = U+005F ; _
+
+        public static bool IsUnderscore(char @char)
+        {
+            return (@char == Constants.UNDERSCORE);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region 7.6.1.5 Boolean value
+
+        #region FALSE = "false" ; keyword: case insensitive
+
+        public static bool IsFalse(string value)
+        {
+            return string.Equals(value, Constants.FALSE, StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
+
+        #region TRUE = "true" ; keyword: case insensitive
+
+        public static bool IsTrue(string value)
+        {
+            return string.Equals(value, Constants.TRUE, StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region 7.6.1.6 Null value
+
+        #region NULL = "null" ; keyword: case insensitive
+
+        public static bool IsNull(string value)
+        {
+            return string.Equals(value, Constants.NULL, StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region 7.7.1 Names
 
         #region IDENTIFIER = firstIdentifierChar *( nextIdentifierChar )
 
@@ -145,7 +325,7 @@ namespace Kingsland.MofParser.Parsing
 
         #endregion
 
-        #region A.13.1 Schema-qualified name
+        #region 7.7.2 Schema-qualified name
 
         #region schemaQualifiedName = schemaName UNDERSCORE IDENTIFIER
 
@@ -155,7 +335,7 @@ namespace Kingsland.MofParser.Parsing
             {
                 return false;
             }
-            var underscore = value.IndexOf(StringValidator.Underscore);
+            var underscore = value.IndexOf(Constants.UNDERSCORE);
             if ((underscore < 1) || (underscore == value.Length - 1))
             {
                 return false;
@@ -199,7 +379,7 @@ namespace Kingsland.MofParser.Parsing
 
         #endregion
 
-        #region A.13.2 Alias identifier
+        #region 7.7.3 Alias identifier
 
         #region aliasIdentifier = "$" IDENTIFIER
 
@@ -208,165 +388,6 @@ namespace Kingsland.MofParser.Parsing
             return !string.IsNullOrEmpty(value) &&
                    (value.First() == '$') &&
                    StringValidator.IsIdentifier(value.Substring(1));
-        }
-
-        #endregion
-
-        #endregion
-
-        #region A.17.1 Integer value
-
-        #region decimalValue = [ "+" / "-" ] unsignedDecimalValue
-
-        public static bool IsDecimalValue(string value)
-        {
-            if (string.IsNullOrEmpty(value)) { return false; }
-            var chars = value.AsEnumerable();
-            if (new[] { '+', '-' }.Contains(chars.First()))
-            {
-                chars = chars.Skip(1);
-            }
-            return StringValidator.IsPositiveDecimalDigit(chars.First()) &&
-                   chars.Skip(1).All(StringValidator.IsDecimalDigit);
-        }
-
-        #endregion
-
-        #region  unsignedDecimalValue = positiveDecimalDigit *decimalDigit
-
-        public static bool IsUnsignedDecimalValue(string value)
-        {
-            if (string.IsNullOrEmpty(value)) { return false; }
-            return StringValidator.IsPositiveDecimalDigit(value.First()) &&
-                   value.Skip(1).All(StringValidator.IsDecimalDigit);
-        }
-
-        #endregion
-
-        #endregion
-
-        #region A.17.2 Real value
-
-        // realValue = ["+" / "-"] * decimalDigit "." 1*decimalDigit
-        //             [ ("e" / "E") [ "+" / "-" ] 1*decimalDigit ]
-
-        #region decimalDigit = "0" / positiveDecimalDigit
-
-        public static bool IsDecimalDigit(char value)
-        {
-            return (value == '0') || StringValidator.IsPositiveDecimalDigit(value);
-        }
-
-        #endregion
-
-        #region positiveDecimalDigit = "1"..."9"
-
-        public static bool IsPositiveDecimalDigit(char value)
-        {
-            return (value >= '1') && (value <= '9');
-        }
-
-        #endregion
-
-        #endregion
-
-        #region A.17.4 Special characters
-
-        // The following special characters are used in other ABNF rules in this specification:
-
-        #region BACKSLASH = U+005C ; \
-
-        public static readonly char Backslash = '\u005C';
-
-        public static bool IsBackslash(char @char)
-        {
-            return (@char == StringValidator.Backslash);
-        }
-
-        #endregion
-
-        #region DOUBLEQUOTE = U+0022 ; "
-
-        public static readonly char DoubleQuote = '\u0022';
-
-        public static bool IsDoubleQuote(char @char)
-        {
-            return (@char == StringValidator.DoubleQuote);
-        }
-
-        #endregion
-
-        #region SINGLEQUOTE = U+0027 ; '
-
-        public static readonly char SingleQuote = '\u0027';
-
-        public static bool IsSingleQuote(char @char)
-        {
-            return (@char == StringValidator.SingleQuote);
-        }
-
-        #endregion
-
-        #region UPPERALPHA = U+0041...U+005A ; A ... Z
-
-        public static bool IsUpperAlpha(char @char)
-        {
-            return (@char >= '\u0041') && (@char <= '\u005A');
-        }
-
-        #endregion
-
-        #region LOWERALPHA = U+0061...U+007A ; a ... z
-
-        public static bool IsLowerAlpha(char @char)
-        {
-            return (@char >= '\u0061') && (@char <= '\u007A');
-        }
-
-        #endregion
-
-        #region UNDERSCORE = U+005F ; _
-
-        public static readonly char Underscore = '\u005F';
-
-        public static bool IsUnderscore(char @char)
-        {
-            return (@char == StringValidator.Underscore);
-        }
-
-        #endregion
-
-        #endregion
-
-        #region A.17.6 Boolean value
-
-        #region FALSE = "false" ; keyword: case insensitive
-
-        public static bool IsFalse(string value)
-        {
-            return string.Equals(value, Constants.FALSE, StringComparison.OrdinalIgnoreCase);
-        }
-
-        #endregion
-
-        #region TRUE = "true" ; keyword: case insensitive
-
-        public static bool IsTrue(string value)
-        {
-            return string.Equals(value, Constants.TRUE, StringComparison.OrdinalIgnoreCase);
-        }
-
-        #endregion
-
-        #endregion
-
-        #region A.17.7 Null value
-
-        #region NULL = "null" ; keyword: case insensitive
-
-        public static bool IsNull(string value)
-        {
-            return string.Equals(value, Constants.NULL, StringComparison.OrdinalIgnoreCase);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Source/SourceReader.cs
+++ b/src/Kingsland.MofParser/Source/SourceReader.cs
@@ -138,6 +138,31 @@ namespace Kingsland.MofParser.Source
         }
 
         /// <summary>
+        /// Reads the current character off of the input stream and advances the current position.
+        /// Throws an exception if the character does not match the specified predicate.
+        /// </summary>
+        /// <returns></returns>
+        public (List<SourceChar>, SourceReader NextReader) ReadWhile(Func<char, bool> predicate)
+        {
+            var thisReader = this;
+            var sourceChar = default(SourceChar);
+            var sourceChars = new List<SourceChar>();
+            while (!thisReader.Eof())
+            {
+                if (predicate(thisReader.Peek().Value))
+                {
+                    (sourceChar, thisReader) = thisReader.Read();
+                    sourceChars.Add(sourceChar);
+                }
+                else
+                {
+                    break;
+                }
+            }
+            return (sourceChars, thisReader);
+        }
+
+        /// <summary>
         /// Reads a string off of the input stream and advances the current position beyond the end of the string.
         /// Throws an exception if the string does not match the specified value.
         /// </summary>

--- a/src/Kingsland.MofParser/Tokens/AliasIdentifierToken.cs
+++ b/src/Kingsland.MofParser/Tokens/AliasIdentifierToken.cs
@@ -18,6 +18,23 @@ namespace Kingsland.MofParser.Tokens
             private set;
         }
 
+        public static bool AreEqual(AliasIdentifierToken obj1, AliasIdentifierToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent) &&
+                       (obj1.Name == obj2.Name);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/AttributeCloseToken.cs
+++ b/src/Kingsland.MofParser/Tokens/AttributeCloseToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(AttributeCloseToken obj1, AttributeCloseToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/AttributeOpenToken.cs
+++ b/src/Kingsland.MofParser/Tokens/AttributeOpenToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(AttributeOpenToken obj1, AttributeOpenToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/BlockCloseToken.cs
+++ b/src/Kingsland.MofParser/Tokens/BlockCloseToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(BlockCloseToken obj1, BlockCloseToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/BlockOpenToken.cs
+++ b/src/Kingsland.MofParser/Tokens/BlockOpenToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(BlockOpenToken obj1, BlockOpenToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/BooleanLiteralToken.cs
+++ b/src/Kingsland.MofParser/Tokens/BooleanLiteralToken.cs
@@ -18,6 +18,23 @@ namespace Kingsland.MofParser.Tokens
             private set;
         }
 
+        public static bool AreEqual(BooleanLiteralToken obj1, BooleanLiteralToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent) &&
+                       (obj1.Value == obj2.Value);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/ColonToken.cs
+++ b/src/Kingsland.MofParser/Tokens/ColonToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(ColonToken obj1, ColonToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/CommaToken.cs
+++ b/src/Kingsland.MofParser/Tokens/CommaToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(CommaToken obj1, CommaToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/CommentToken.cs
+++ b/src/Kingsland.MofParser/Tokens/CommentToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(CommentToken obj1, CommentToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/EqualsOperatorToken.cs
+++ b/src/Kingsland.MofParser/Tokens/EqualsOperatorToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(EqualsOperatorToken obj1, EqualsOperatorToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/IdentifierToken.cs
+++ b/src/Kingsland.MofParser/Tokens/IdentifierToken.cs
@@ -28,6 +28,22 @@ namespace Kingsland.MofParser.Tokens
             return name.ToLowerInvariant();
         }
 
+        public static bool AreEqual(IdentifierToken obj1, IdentifierToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent) &&
+                       (obj1.Name == obj2.Name);
+            }
+        }
 
     }
 

--- a/src/Kingsland.MofParser/Tokens/IntegerLiteralToken.cs
+++ b/src/Kingsland.MofParser/Tokens/IntegerLiteralToken.cs
@@ -18,6 +18,23 @@ namespace Kingsland.MofParser.Tokens
             private set;
         }
 
+        public static bool AreEqual(IntegerLiteralToken obj1, IntegerLiteralToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent) &&
+                       (obj1.Value == obj2.Value);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/NullLiteralToken.cs
+++ b/src/Kingsland.MofParser/Tokens/NullLiteralToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(NullLiteralToken obj1, NullLiteralToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/ParenthesesCloseToken.cs
+++ b/src/Kingsland.MofParser/Tokens/ParenthesesCloseToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(ParenthesesCloseToken obj1, ParenthesesCloseToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/ParenthesesOpenToken.cs
+++ b/src/Kingsland.MofParser/Tokens/ParenthesesOpenToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(ParenthesesOpenToken obj1, ParenthesesOpenToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/PragmaToken.cs
+++ b/src/Kingsland.MofParser/Tokens/PragmaToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(PragmaToken obj1, PragmaToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/RealLiteralToken.cs
+++ b/src/Kingsland.MofParser/Tokens/RealLiteralToken.cs
@@ -1,0 +1,40 @@
+﻿using Kingsland.MofParser.Source;
+
+namespace Kingsland.MofParser.Tokens
+{
+
+    public sealed class RealLiteralToken : Token
+    {
+
+        public RealLiteralToken(SourceExtent extent, double value)
+            : base(extent)
+        {
+            this.Value = value;
+        }
+
+        public double Value
+        {
+            get;
+            private set;
+        }
+
+        public static bool AreEqual(RealLiteralToken obj1, RealLiteralToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent) &&
+                       (obj1.Value == obj2.Value);
+            }
+        }
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Tokens/StatementEndToken.cs
+++ b/src/Kingsland.MofParser/Tokens/StatementEndToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(StatementEndToken obj1, StatementEndToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/StringLiteralToken.cs
+++ b/src/Kingsland.MofParser/Tokens/StringLiteralToken.cs
@@ -18,6 +18,23 @@ namespace Kingsland.MofParser.Tokens
             private set;
         }
 
+        public static bool AreEqual(StringLiteralToken obj1, StringLiteralToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent) &&
+                       (obj1.Value == obj2.Value);
+            }
+        }
+
     }
 
 }

--- a/src/Kingsland.MofParser/Tokens/WhitespaceToken.cs
+++ b/src/Kingsland.MofParser/Tokens/WhitespaceToken.cs
@@ -11,6 +11,22 @@ namespace Kingsland.MofParser.Tokens
         {
         }
 
+        public static bool AreEqual(WhitespaceToken obj1, WhitespaceToken obj2)
+        {
+            if ((obj1 == null) && (obj2 == null))
+            {
+                return true;
+            }
+            else if ((obj1 == null) || (obj2 == null))
+            {
+                return false;
+            }
+            else
+            {
+                return obj1.Extent.IsEqualTo(obj2.Extent);
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
+ Fixes and compatibility with MOF spec v3.0.0 -> v3.0.1, and tests / fixes for MofGenerator
+ Completely rewritten Integer and Real lexing - supports everything (binary, octal, hex, decimal, real) except realValue exponents