### PR TITLE
Changes for compatibility with MOF 3.0.1 spec

### DIFF
--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -1,7 +1,10 @@
 ﻿using Kingsland.MofParser.CodeGen;
 using Kingsland.MofParser.Parsing;
 using Kingsland.MofParser.Source;
+using Kingsland.MofParser.UnitTests.Helpers;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Kingsland.MofParser.UnitTests.CodeGen
 {
@@ -11,6 +14,8 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
 
         public static class ConvertToMofTests
         {
+
+            #region Individual Roundtrip Tests
 
             [Test]
             public static void BooleanValueAstShouldRoundtrip()
@@ -75,6 +80,56 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var actualMof = MofGenerator.ConvertToMof(actualAst);
                 Assert.AreEqual(expectedMof, actualMof);
             }
+
+            #endregion
+
+            #region Roundtrip Test Cases
+
+            //[TestFixture]
+            //public static class ConvertToMofMethodTestCasesWmiWinXp
+            //{
+            //    [Test, TestCaseSource(typeof(ConvertToMofMethodTestCasesWmiWinXp), "GetTestCases")]
+            //    public static void ConvertToMofMethodTestsFromDisk(string mofFilename)
+            //    {
+            //        ConvertToMofTests.MofGeneratorRoundtripTest(mofFilename);
+            //    }
+            //    public static IEnumerable<TestCaseData> GetTestCases
+            //    {
+            //        get
+            //        {
+            //            return TestUtils.GetMofTestCase("Parsing\\WMI\\WinXp");
+            //        }
+            //    }
+            //}
+
+            //[TestFixture]
+            //public static class ConvertToMofMethodGolfExamples
+            //{
+            //    //[Test, TestCaseSource(typeof(ConvertToMofMethodGolfExamples), "GetTestCases")]
+            //    public static void ConvertToMofMethodTestsFromDisk(string mofFilename)
+            //    {
+            //        ConvertToMofTests.MofGeneratorRoundtripTest(mofFilename);
+            //    }
+            //    public static IEnumerable<TestCaseData> GetTestCases
+            //    {
+            //        get
+            //        {
+            //            return TestUtils.GetMofTestCase("Parsing\\DSP0221_3.0.1");
+            //        }
+            //    }
+            //}
+
+            //private static void MofGeneratorRoundtripTest(string mofFilename)
+            //{
+            //    var expectedMof = File.ReadAllText(mofFilename);
+            //    var reader = SourceReader.From(expectedMof);
+            //    var tokens = Lexing.Lexer.Lex(reader);
+            //    var ast = Parser.Parse(tokens);
+            //    var actualMof = MofGenerator.ConvertToMof(ast);
+            //    Assert.AreEqual(expectedMof, actualMof);
+            //}
+
+            #endregion
 
         }
 

--- a/src/Kingsland.MofParser.UnitTests/Kingsland.MofParser.UnitTests.csproj
+++ b/src/Kingsland.MofParser.UnitTests/Kingsland.MofParser.UnitTests.csproj
@@ -117,6 +117,24 @@
     <Content Include="Parsing\DSP0221_3.0.1\D.20 JohnDoe.mof">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Parsing\WMI\WinXp\WinXpProSp3CIMV2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Parsing\WMI\WinXp\WinXpProSp3CIMV2.mof">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Parsing\WMI\WinXp\WinXpProSp3Microsoft.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Parsing\WMI\WinXp\WinXpProSp3Microsoft.mof">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Parsing\WMI\WinXp\WinXpProSp3WMI.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Parsing\WMI\WinXp\WinXpProSp3WMI.mof">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Kingsland.MofParser.UnitTests/Lexer/LexerTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Lexer/LexerTests.cs
@@ -1925,24 +1925,28 @@ namespace Kingsland.MofParser.UnitTests.Lexer
         [TestFixture]
         public static class LexMethodTestCases
         {
-
             [Test, TestCaseSource(typeof(LexMethodTestCases), "GetTestCases")]
             public static void LexMethodTestsFromDisk(string mofFilename)
             {
-                var mofText = File.ReadAllText(mofFilename);
-                var reader = SourceReader.From(mofText);
-                var actualTokens = Lexing.Lexer.Lex(reader);
-                var actualText = TestUtils.ConvertToJson(actualTokens);
-                var expectedFilename = Path.Combine(Path.GetDirectoryName(mofFilename),
-                                                    Path.GetFileNameWithoutExtension(mofFilename) + ".json");
-                if (!File.Exists(expectedFilename))
-                {
-                    File.WriteAllText(expectedFilename, actualText);
-                }
-                var expectedText = File.ReadAllText(expectedFilename);
-                Assert.AreEqual(expectedText, actualText);
+                LexerTests.LexMethodTest(mofFilename);
             }
+            public static IEnumerable<TestCaseData> GetTestCases
+            {
+                get
+                {
+                    return TestUtils.GetMofTestCase("cim_schema_2.51.0Final-MOFs");
+                }
+            }
+        }
 
+        [TestFixture]
+        public static class LexCimSpec
+        {
+            //[Test, TestCaseSource(typeof(LexCimSpec), "GetTestCases")]
+            public static void LexMethodTestsFromDisk(string mofFilename)
+            {
+                LexerTests.LexMethodTest(mofFilename);
+            }
             public static IEnumerable<TestCaseData> GetTestCases
             {
                 get
@@ -1950,7 +1954,23 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                     return TestUtils.GetMofTestCase("Lexer\\TestCases");
                 }
             }
+        }
 
+
+        private static void LexMethodTest(string mofFilename)
+        {
+            var mofText = File.ReadAllText(mofFilename);
+            var reader = SourceReader.From(mofText);
+            var actualTokens = Lexing.Lexer.Lex(reader);
+            var actualText = TestUtils.ConvertToJson(actualTokens);
+            var expectedFilename = Path.Combine(Path.GetDirectoryName(mofFilename),
+                                                Path.GetFileNameWithoutExtension(mofFilename) + ".json");
+            if (!File.Exists(expectedFilename))
+            {
+                File.WriteAllText(expectedFilename, actualText);
+            }
+            var expectedText = File.ReadAllText(expectedFilename);
+            Assert.AreEqual(expectedText, actualText);
         }
 
     }

--- a/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 
-namespace Kingsland.MofParser.UnitTests.Lexer
+namespace Kingsland.MofParser.UnitTests.Parsing
 {
 
     public static class ParserTests
@@ -558,12 +558,13 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                 Assert.AreEqual(expectedJson, actualJson);
             }
 
-
         }
 
+        //[TestFixture]
         //private static class ParseMethodTestCasesWmiWin81
         //{
-        //    public static IEnumerable TestCases
+        //    [Test, TestCaseSource(typeof(LexMethodTestCases), "GetTestCases")]
+        //    public static IEnumerable<TestCaseData> TestCases
         //    {
         //        get
         //        {
@@ -572,40 +573,30 @@ namespace Kingsland.MofParser.UnitTests.Lexer
         //    }
         //}
 
-        //private static class ParseMethodTestCasesWmiWinXp
-        //{
-        //    public static IEnumerable TestCases
-        //    {
-        //        get
-        //        {
-        //            return TestUtils.GetMofTestCase("Parsing\\WMI\\WinXp");
-        //        }
-        //    }
-        //}
+        public static class ParseMethodTestCasesWmiWinXp
+        {
+            [Test, TestCaseSource(typeof(ParseMethodTestCasesWmiWinXp), "GetTestCases")]
+            public static void ParseMethodTestsFromDisk(string mofFilename)
+            {
+                ParserTests.ParseMethodTest(mofFilename);
+            }
+            public static IEnumerable<TestCaseData> GetTestCases
+            {
+                get
+                {
+                    return TestUtils.GetMofTestCase("Parsing\\WMI\\WinXp");
+                }
+            }
+        }
 
         [TestFixture]
         public static class ParseMethodGolfExamples
         {
-
             //[Test, TestCaseSource(typeof(ParseMethodGolfExamples), "GetTestCases")]
             public static void ParseMethodTestsFromDisk(string mofFilename)
             {
-                //Console.WriteLine(mofFilename);
-                var mofText = File.ReadAllText(mofFilename);
-                var reader = SourceReader.From(mofText);
-                var tokens = Lexing.Lexer.Lex(reader);
-                var ast = Parser.Parse(tokens);
-                var actualText = TestUtils.ConvertToJson(ast);
-                var expectedFilename = Path.Combine(Path.GetDirectoryName(mofFilename),
-                                                    Path.GetFileNameWithoutExtension(mofFilename) + ".json");
-                if (!File.Exists(expectedFilename))
-                {
-                    File.WriteAllText(expectedFilename, actualText);
-                }
-                var expectedText = File.ReadAllText(expectedFilename);
-                Assert.AreEqual(expectedText, actualText);
+                ParserTests.ParseMethodTest(mofFilename);
             }
-
             public static IEnumerable<TestCaseData> GetTestCases
             {
                 get
@@ -613,7 +604,24 @@ namespace Kingsland.MofParser.UnitTests.Lexer
                     return TestUtils.GetMofTestCase("Parsing\\DSP0221_3.0.1");
                 }
             }
+        }
 
+        private static void ParseMethodTest(string mofFilename)
+        {
+            //Console.WriteLine(mofFilename);
+            var mofText = File.ReadAllText(mofFilename);
+            var reader = SourceReader.From(mofText);
+            var tokens = Lexing.Lexer.Lex(reader);
+            var ast = Parser.Parse(tokens);
+            var actualText = TestUtils.ConvertToJson(ast);
+            var expectedFilename = Path.Combine(Path.GetDirectoryName(mofFilename),
+                                                Path.GetFileNameWithoutExtension(mofFilename) + ".json");
+            if (!File.Exists(expectedFilename))
+            {
+                File.WriteAllText(expectedFilename, actualText);
+            }
+            var expectedText = File.ReadAllText(expectedFilename);
+            Assert.AreEqual(expectedText, actualText);
         }
 
     }

--- a/src/Kingsland.MofParser/Ast/ParameterDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/ParameterDeclarationAst.cs
@@ -20,8 +20,7 @@ namespace Kingsland.MofParser.Ast
     ///                                 referenceParamDeclaration )
     ///
     ///     primitiveParamDeclaration = primitiveType parameterName [ array ]
-    ///                                 [ "=" primitiveTypeValue
-    ///                                 ]
+    ///                                 [ "=" primitiveTypeValue ]
     ///
     ///     complexParamDeclaration   = structureOrClassName parameterName [ array ]
     ///                                 [ "=" ( complexTypeValue / aliasIdentifier ) ]
@@ -111,7 +110,7 @@ namespace Kingsland.MofParser.Ast
             this.Type = type ?? throw new ArgumentNullException(nameof(type));
             this.IsRef = isRef;
             this.IsArray = isArray;
-            this.DefaultValue = defaultValue ?? throw new ArgumentNullException(nameof(defaultValue));
+            this.DefaultValue = defaultValue;
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Lexing/LexerEngine.cs
+++ b/src/Kingsland.MofParser/Lexing/LexerEngine.cs
@@ -619,6 +619,7 @@ namespace Kingsland.MofParser.Lexing
             const int stateDecimalValue = 7;
             const int stateRealValue = 8;
             const int stateRealValueFraction = 9;
+            const int stateRealValueExponent = 10;
             const int stateDone = 99;
 
             var thisReader = reader;
@@ -840,7 +841,8 @@ namespace Kingsland.MofParser.Lexing
                             sourceChar = thisReader.Peek();
                             if ((sourceChar.Value == 'e') || (sourceChar.Value == 'E'))
                             {
-                                throw new NotImplementedException();
+                                currentState = stateRealValueExponent;
+                                break;
                             }
                         }
                         // build the return value
@@ -858,7 +860,11 @@ namespace Kingsland.MofParser.Lexing
                         currentState = stateDone;
                         break;
 
+                    case stateRealValueExponent:
+                        throw new InvalidOperationException();
+
                     case stateDone:
+                        // the main while loop should exit before we ever get here
                         throw new InvalidOperationException();
 
                     default:


### PR DESCRIPTION
Changes for compatibility with MOF 3.0.1 spec:

+ ParseQualifierDeclarationAst now throws as it doesn't match the spec

+ Refactoring ParseQualifierValueAst to use new ParseQualifierValueInitializer and ParseQualifierValueArrayInitializer methods

+ Cleanup of other node parsers to better match spec:
  - ParseParameterDeclarationAst
  - ParseComplexTypeValueAst
  - ParseLiteralValueArrayAst