### PR TITLE
Fixes for #18, #19, #20, #21, #22, #23

### DIFF
--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -23,7 +23,7 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var expectedMof =
                     "instance of GOLF_ClubMember\r\n" +
                     "{\r\n" +
-                    "    Caption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
+                    "\tCaption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
                     "};";
                 var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
                 var actualAst = Parser.Parse(actualTokens);
@@ -41,7 +41,7 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var expectedMof =
                     "instance of myType as $Alias00000070\r\n" +
                     "{\r\n" +
-                    "    Reference = TRUE;\r\n" +
+                    "\tReference = TRUE;\r\n" +
                     "};";
                 var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
                 var actualAst = Parser.Parse(actualTokens);
@@ -91,11 +91,11 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var expectedMof =
                     "instance of myType as $Alias00000070\r\n" +
                     "{\r\n" +
-                    "    MyBinaryValue = 0101010b;\r\n" +
-                    "    MyOctalValue = 0444444;\r\n" +
-                    "    MyHexValue = 0xABC123;\r\n" +
-                    "    MyDecimalValue = 12345;\r\n" +
-                    "    MyRealValue = 123.45;\r\n" +
+                    "\tMyBinaryValue = 0101010b;\r\n" +
+                    "\tMyOctalValue = 0444444;\r\n" +
+                    "\tMyHexValue = 0xABC123;\r\n" +
+                    "\tMyDecimalValue = 12345;\r\n" +
+                    "\tMyRealValue = 123.45;\r\n" +
                     "};";
                 var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
                 var actualAst = Parser.Parse(actualTokens);
@@ -180,7 +180,7 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var expectedMof =
                     "instance of GOLF_ClubMember\r\n" +
                     "{\r\n" +
-                    "    Caption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
+                    "\tCaption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
                     "};";
                 var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
                 var actualAst = Parser.Parse(actualTokens);
@@ -209,7 +209,6 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var actualMof = MofGenerator.ConvertToMof(actualAst);
                 Assert.AreEqual(expectedMof, actualMof);
             }
-
 
             [Test]
             public static void StructureValueDeclarationAstShouldRoundtrip()

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -170,6 +170,8 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 Assert.AreEqual(expectedMof, actualMof);
             }
 
+            #endregion
+
             #region 7.5.3 Association declaration
 
             [Test]

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -15,7 +15,25 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
         public static class ConvertToMofTests
         {
 
-            #region Individual Roundtrip Tests
+            #region 7.6.1.3 String values
+
+            [Test]
+            public static void StringValueWithSinglewQuoteShouldRoundtrip()
+            {
+                var expectedMof =
+                    "instance of GOLF_ClubMember\r\n" +
+                    "{\r\n" +
+                    "    Caption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            #endregion
+
+            #region 7.6.1.5 Boolean value
 
             [Test]
             public static void BooleanValueAstShouldRoundtrip()
@@ -30,6 +48,10 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var actualMof = MofGenerator.ConvertToMof(actualAst);
                 Assert.AreEqual(expectedMof, actualMof);
             }
+
+            #endregion
+
+            #region 7.5.2 Class declaration
 
             [Test]
             public static void ClassDeclarationsAstWithQualifiersShouldRoundtrip()
@@ -128,6 +150,8 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 Assert.AreEqual(expectedMof, actualMof);
             }
 
+            #endregion
+
             #region 7.5.1 Structure declaration
 
             [Test]
@@ -147,6 +171,60 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
             }
 
             #endregion
+
+            #region 7.6.2 Complex type value
+
+            [Test]
+            public static void InstanceValueDeclarationShouldRoundtrip()
+            {
+                var expectedMof =
+                    "instance of GOLF_ClubMember\r\n" +
+                    "{\r\n" +
+                    "    Caption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            [Test]
+            public static void InstanceValueDeclarationWithLocalStructureValueDeclarationPropertyShouldRoundtrip()
+            {
+                var expectedMof =
+                    "instance of GOLF_ClubMember\r\n" +
+                    "{\r\n" +
+                    "\tCaption = \"Instance of John Doe\\\'s GOLF_ClubMember object\"\r\n; " +
+                    "\tMemberAddress = value of GOLF_Address\r\n" +
+                    "\t{\r\n" +
+                    "\t\tState = \"IL\"\r\n;" +
+                    "\t\tCity = \"Oak Park\"\r\n;" +
+                    "\t\tStreet = \"Oak Park Av.\";\r\n" +
+                    "\t\tStreetNo = \"1177\";\r\n" +
+                    "\t\tApartmentNo = \"3B\";\r\n" +
+                    "\t};\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+
+            [Test]
+            public static void StructureValueDeclarationAstShouldRoundtrip()
+            {
+                var expectedMof =
+                    "value of GOLF_PhoneNumber as $JohnDoesPhoneNo\r\n" +
+                    "{\r\n" +
+                    "\tAreaCode = {\"9\", \"0\", \"7\"};\r\n" +
+                    "\tNumber = {\"7\", \"4\", \"7\", \"4\", \"8\", \"8\", \"4\"};\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
 
             #endregion
 

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -18,7 +18,7 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
             #region 7.6.1.3 String values
 
             [Test]
-            public static void StringValueWithSinglewQuoteShouldRoundtrip()
+            public static void StringValueWithSingleQuoteShouldRoundtrip()
             {
                 var expectedMof =
                     "instance of GOLF_ClubMember\r\n" +
@@ -163,6 +163,24 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                     "\tstring Name;\r\n" +
                     "\tGOLF_Date ContractSignedDate;\r\n" +
                     "\treal32 ContractAmount;\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            #region 7.5.3 Association declaration
+
+            [Test]
+            public static void AssociationDeclarationAstShouldRoundtrip()
+            {
+                var expectedMof =
+                    "association GOLF_MemberLocker : GOLF_Base\r\n" +
+                    "{\r\n" +
+                    "\tGOLF_ClubMember REF Member;\r\n" +
+                    "\tGOLF_Locker REF Locker;\r\n" +
+                    "\tGOLF_Date AssignedOnDate;\r\n" +
                     "};";
                 var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
                 var actualAst = Parser.Parse(actualTokens);

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -170,6 +170,34 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 Assert.AreEqual(expectedMof, actualMof);
             }
 
+            [Test]
+            public static void StructureDeclarationAstWithLocalEnumerationDeclarationShouldRoundtrip()
+            {
+                var expectedMof =
+                    "structure GOLF_Date\r\n" +
+                    "{\r\n" +
+                    "\tenumeration MonthsEnum : String\r\n" +
+                    "\t{\r\n" +
+                    "\t\tJanuary,\r\n" +
+                    "\t\tFebruary,\r\n" +
+                    "\t\tMarch,\r\n" +
+                    "\t\tApril,\r\n" +
+                    "\t\tMay,\r\n" +
+                    "\t\tJune,\r\n" +
+                    "\t\tJuly,\r\n" +
+                    "\t\tAugust,\r\n" +
+                    "\t\tSeptember,\r\n" +
+                    "\t\tOctober,\r\n" +
+                    "\t\tNovember,\r\n" +
+                    "\t\tDecember\r\n" +
+                    "\t};\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
             #endregion
 
             #region 7.5.3 Association declaration
@@ -183,6 +211,35 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                     "\tGOLF_ClubMember REF Member;\r\n" +
                     "\tGOLF_Locker REF Locker;\r\n" +
                     "\tGOLF_Date AssignedOnDate;\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            #endregion
+
+            #region 7.5.4 Enumeration declaration
+
+            [Test]
+            public static void EnumerationDeclarationAstShouldRoundtrip()
+            {
+                var expectedMof =
+                    "enumeration MonthsEnum : String\r\n" +
+                    "{\r\n" +
+                    "\tJanuary,\r\n" +
+                    "\tFebruary,\r\n" +
+                    "\tMarch,\r\n" +
+                    "\tApril,\r\n" +
+                    "\tMay,\r\n" +
+                    "\tJune,\r\n" +
+                    "\tJuly,\r\n" +
+                    "\tAugust,\r\n" +
+                    "\tSeptember,\r\n" +
+                    "\tOctober,\r\n" +
+                    "\tNovember,\r\n" +
+                    "\tDecember\r\n" +
                     "};";
                 var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
                 var actualAst = Parser.Parse(actualTokens);

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -109,6 +109,45 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 Assert.AreEqual(expectedMof, actualMof);
             }
 
+            [Test]
+            public static void ClassDeclarationsAstWithStructureDeclarationPropertyShouldRoundtrip()
+            {
+                var expectedMof =
+                    "class GOLF_Professional : GOLF_ClubMember\r\n" +
+                    "{\r\n" +
+                    "\tstructure Sponsor\r\n" +
+                    "\t{\r\n" +
+                    "\t\tstring Name;\r\n" +
+                    "\t\tGOLF_Date ContractSignedDate;\r\n" +
+                    "\t\treal32 ContractAmount;\r\n" +
+                    "\t};\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            #region 7.5.1 Structure declaration
+
+            [Test]
+            public static void StructureDeclarationAstShouldRoundtrip()
+            {
+                var expectedMof =
+                    "structure Sponsor\r\n" +
+                    "{\r\n" +
+                    "\tstring Name;\r\n" +
+                    "\tGOLF_Date ContractSignedDate;\r\n" +
+                    "\treal32 ContractAmount;\r\n" +
+                    "};";
+                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
+                var actualAst = Parser.Parse(actualTokens);
+                var actualMof = MofGenerator.ConvertToMof(actualAst);
+                Assert.AreEqual(expectedMof, actualMof);
+            }
+
+            #endregion
+
             #endregion
 
             #region Roundtrip Test Cases

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -194,11 +194,11 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 var expectedMof =
                     "instance of GOLF_ClubMember\r\n" +
                     "{\r\n" +
-                    "\tCaption = \"Instance of John Doe\\\'s GOLF_ClubMember object\"\r\n; " +
+                    "\tCaption = \"Instance of John Doe\\\'s GOLF_ClubMember object\";\r\n" +
                     "\tMemberAddress = value of GOLF_Address\r\n" +
                     "\t{\r\n" +
-                    "\t\tState = \"IL\"\r\n;" +
-                    "\t\tCity = \"Oak Park\"\r\n;" +
+                    "\t\tState = \"IL\";\r\n" +
+                    "\t\tCity = \"Oak Park\";\r\n" +
                     "\t\tStreet = \"Oak Park Av.\";\r\n" +
                     "\t\tStreetNo = \"1177\";\r\n" +
                     "\t\tApartmentNo = \"3B\";\r\n" +

--- a/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
@@ -172,7 +172,6 @@ namespace Kingsland.MofParser.UnitTests.Parsing
                                     new ReadOnlyDictionary<string, PropertyValueAst>(
                                         new Dictionary<string, PropertyValueAst> {
                                             { "Reference", new ComplexValueAst(
-                                                true, false,
                                                 new AliasIdentifierToken(
                                                     new SourceExtent(
                                                         new SourcePosition(57, 3, 17),
@@ -180,18 +179,9 @@ namespace Kingsland.MofParser.UnitTests.Parsing
                                                         "$Alias0000006E"
                                                     ),
                                                     "Alias0000006E"
-                                                ),
-                                                new IdentifierToken(
-                                                    new SourceExtent(
-                                                        new SourcePosition(12, 1, 13),
-                                                        new SourcePosition(17, 1, 18),
-                                                        "myType"
-                                                    ),
-                                                    "myType"
-                                                ),
-                                                null
-                                            )
-                                        }}
+                                                )
+                                            )}
+                                        }
                                     )
                                 ),
                                 new StatementEndToken(
@@ -354,7 +344,6 @@ namespace Kingsland.MofParser.UnitTests.Parsing
                                                 new ReadOnlyCollection<ComplexValueAst>(
                                                     new List<ComplexValueAst> {
                                                         new ComplexValueAst(
-                                                            true, false,
                                                             new AliasIdentifierToken(
                                                                 new SourceExtent(
                                                                     new SourcePosition(58, 3, 18),
@@ -362,16 +351,7 @@ namespace Kingsland.MofParser.UnitTests.Parsing
                                                                     "$Alias0000006E"
                                                                 ),
                                                                 "Alias0000006E"
-                                                            ),
-                                                            new IdentifierToken(
-                                                                new SourceExtent(
-                                                                    new SourcePosition(12, 1, 13),
-                                                                    new SourcePosition(17, 1, 18),
-                                                                    "myType"
-                                                                ),
-                                                                "myType"
-                                                            ),
-                                                            null
+                                                            )
                                                         )
                                                     }
                                                 )

--- a/src/Kingsland.MofParser/Ast/AssociationDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/AssociationDeclarationAst.cs
@@ -13,20 +13,18 @@ namespace Kingsland.MofParser.Ast
     ///
     /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
     ///
-    /// 7.5.2 Class declaration
+    /// 7.5.3 Association declaration
     ///
-    ///     classDeclaration = [ qualifierList ] CLASS className [ superClass ]
-    ///                        "{" *classFeature "}" ";"
+    ///     associationDeclaration = [ qualifierList ] ASSOCIATION associationName
+    ///                              [ superAssociation ]
+    ///                              "{" * classFeature "}" ";"
     ///
-    ///     className        = elementName
-    ///     superClass       = ":" className
-    ///     classFeature     = structureFeature /
-    ///                        methodDeclaration
+    ///     associationName        = elementName
+    ///     superAssociation       = ":" elementName
     ///
-    ///     CLASS            = "class" ; keyword: case insensitive
-    ///
+    ///     ASSOCIATION            = "association" ; keyword: case insensitive
     /// </remarks>
-    public sealed class ClassDeclarationAst : MofProductionAst
+    public sealed class AssociationDeclarationAst : MofProductionAst
     {
 
         #region Builder
@@ -45,13 +43,13 @@ namespace Kingsland.MofParser.Ast
                 set;
             }
 
-            public IdentifierToken ClassName
+            public IdentifierToken AssociationName
             {
                 get;
                 set;
             }
 
-            public IdentifierToken SuperClass
+            public IdentifierToken SuperAssociation
             {
                 get;
                 set;
@@ -63,12 +61,12 @@ namespace Kingsland.MofParser.Ast
                 set;
             }
 
-            public ClassDeclarationAst Build()
+            public AssociationDeclarationAst Build()
             {
-                return new ClassDeclarationAst(
+                return new AssociationDeclarationAst(
                     this.Qualifiers,
-                    this.ClassName,
-                    this.SuperClass,
+                    this.AssociationName,
+                    this.SuperAssociation,
                     new ReadOnlyCollection<IClassFeatureAst>(
                         this.Features ?? new List<IClassFeatureAst>()
                     )
@@ -81,11 +79,11 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public ClassDeclarationAst(QualifierListAst qualifiers, IdentifierToken className, IdentifierToken superClass, ReadOnlyCollection<IClassFeatureAst> features)
+        public AssociationDeclarationAst(QualifierListAst qualifiers, IdentifierToken associationName, IdentifierToken superAssociation, ReadOnlyCollection<IClassFeatureAst> features)
         {
             this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
-            this.ClassName = className ?? throw new ArgumentNullException(nameof(className));
-            this.SuperClass = superClass;
+            this.AssociationName = associationName ?? throw new ArgumentNullException(nameof(associationName));
+            this.SuperAssociation = superAssociation;
             this.Features = features ?? new ReadOnlyCollection<IClassFeatureAst>(new List<IClassFeatureAst>());
         }
 
@@ -99,13 +97,13 @@ namespace Kingsland.MofParser.Ast
             private set;
         }
 
-        public IdentifierToken ClassName
+        public IdentifierToken AssociationName
         {
             get;
             private set;
         }
 
-        public IdentifierToken SuperClass
+        public IdentifierToken SuperAssociation
         {
             get;
             private set;
@@ -123,7 +121,7 @@ namespace Kingsland.MofParser.Ast
 
         public override string ToString()
         {
-            return MofGenerator.ConvertClassDeclarationAst(this);
+            return MofGenerator.ConvertAssociationDeclarationAst(this);
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Ast/ClassDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/ClassDeclarationAst.cs
@@ -36,7 +36,7 @@ namespace Kingsland.MofParser.Ast
 
             public Builder()
             {
-                this.Features = new List<ClassFeatureAst>();
+                this.Features = new List<IClassFeatureAst>();
             }
 
             public QualifierListAst Qualifiers
@@ -57,7 +57,7 @@ namespace Kingsland.MofParser.Ast
                 set;
             }
 
-            public List<ClassFeatureAst> Features
+            public List<IClassFeatureAst> Features
             {
                 get;
                 set;
@@ -69,8 +69,8 @@ namespace Kingsland.MofParser.Ast
                     this.Qualifiers,
                     this.ClassName,
                     this.Superclass,
-                    new ReadOnlyCollection<ClassFeatureAst>(
-                        this.Features ?? new List<ClassFeatureAst>()
+                    new ReadOnlyCollection<IClassFeatureAst>(
+                        this.Features ?? new List<IClassFeatureAst>()
                     )
                 );
             }
@@ -81,12 +81,12 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public ClassDeclarationAst(QualifierListAst qualifiers, IdentifierToken className, IdentifierToken superClass, ReadOnlyCollection<ClassFeatureAst> features)
+        public ClassDeclarationAst(QualifierListAst qualifiers, IdentifierToken className, IdentifierToken superClass, ReadOnlyCollection<IClassFeatureAst> features)
         {
             this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
             this.ClassName = className ?? throw new ArgumentNullException(nameof(className));
             this.Superclass = superClass;
-            this.Features = features ?? new ReadOnlyCollection<ClassFeatureAst>(new List<ClassFeatureAst>());
+            this.Features = features ?? new ReadOnlyCollection<IClassFeatureAst>(new List<IClassFeatureAst>());
         }
 
         #endregion
@@ -111,7 +111,7 @@ namespace Kingsland.MofParser.Ast
             private set;
         }
 
-        public ReadOnlyCollection<ClassFeatureAst> Features
+        public ReadOnlyCollection<IClassFeatureAst> Features
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/ComplexTypeValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/ComplexTypeValueAst.cs
@@ -17,7 +17,7 @@
 
         #region Constructors
 
-        protected ComplexTypeValueAst()
+        internal ComplexTypeValueAst()
         {
         }
 

--- a/src/Kingsland.MofParser/Ast/ComplexValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/ComplexValueAst.cs
@@ -1,5 +1,6 @@
 ﻿using Kingsland.MofParser.CodeGen;
 using Kingsland.MofParser.Tokens;
+using System;
 
 namespace Kingsland.MofParser.Ast
 {
@@ -26,19 +27,19 @@ namespace Kingsland.MofParser.Ast
         public sealed class Builder
         {
 
-            public bool IsAlias
-            {
-                get;
-                set;
-            }
-
-            public bool IsValue
-            {
-                get;
-                set;
-            }
-
             public AliasIdentifierToken Alias
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken Value
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken Of
             {
                 get;
                 set;
@@ -50,7 +51,7 @@ namespace Kingsland.MofParser.Ast
                 set;
             }
 
-            public PropertyValueListAst Properties
+            public PropertyValueListAst PropertyValues
             {
                 get;
                 set;
@@ -58,13 +59,21 @@ namespace Kingsland.MofParser.Ast
 
             public ComplexValueAst Build()
             {
-                return new ComplexValueAst(
-                    this.IsAlias,
-                    this.IsValue,
-                    this.Alias,
-                    this.TypeName,
-                    this.Properties
-                );
+                if (!(this.Alias == null))
+                {
+                    return new ComplexValueAst(
+                        this.Alias
+                    );
+                }
+                else
+                {
+                    return new ComplexValueAst(
+                        this.Value,
+                        this.Of,
+                        this.TypeName,
+                        this.PropertyValues
+                    );
+                }
             }
 
         }
@@ -74,18 +83,28 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         public ComplexValueAst(
-            bool isAlias,
-            bool isValue,
-            AliasIdentifierToken alias,
-            IdentifierToken typeName,
-            PropertyValueListAst properties
+            AliasIdentifierToken alias
         )
         {
-            this.IsAlias = isAlias;
-            this.IsValue = isValue;
-            this.Alias = alias;
-            this.TypeName = TypeName;
-            this.Properties = properties ?? new PropertyValueListAst.Builder().Build();
+            this.Alias = alias ?? throw new ArgumentException(nameof(alias));
+            this.Value = null;
+            this.Of = null;
+            this.TypeName = null;
+            this.PropertyValues = new PropertyValueListAst.Builder().Build();
+        }
+
+        public ComplexValueAst(
+            IdentifierToken value,
+            IdentifierToken of,
+            IdentifierToken typeName,
+            PropertyValueListAst propertyValues
+        )
+        {
+            this.Alias = null;
+            this.Value = value ?? throw new ArgumentException(nameof(value));
+            this.Of = of;
+            this.TypeName = typeName;
+            this.PropertyValues = propertyValues ?? new PropertyValueListAst.Builder().Build();
         }
 
         #endregion
@@ -94,17 +113,33 @@ namespace Kingsland.MofParser.Ast
 
         public bool IsAlias
         {
-            get;
-            private set;
+            get
+            {
+                return !(this.Alias == null);
+            }
         }
 
         public bool IsValue
+        {
+            get
+            {
+                return !(this.Value == null);
+            }
+        }
+
+        public AliasIdentifierToken Alias
         {
             get;
             private set;
         }
 
-        public AliasIdentifierToken Alias
+        public IdentifierToken Value
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken Of
         {
             get;
             private set;
@@ -116,7 +151,7 @@ namespace Kingsland.MofParser.Ast
             private set;
         }
 
-        public PropertyValueListAst Properties
+        public PropertyValueListAst PropertyValues
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/EnumElementAst.cs
+++ b/src/Kingsland.MofParser/Ast/EnumElementAst.cs
@@ -1,0 +1,105 @@
+﻿using Kingsland.MofParser.CodeGen;
+using Kingsland.MofParser.Tokens;
+
+namespace Kingsland.MofParser.Ast
+{
+
+    /// <summary>
+    /// </summary>
+    /// <returns></returns>
+    /// <remarks>
+    ///
+    /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
+    ///
+    /// 7.5.4 Enumeration declaration
+    ///
+    ///     integerEnumElement     = [ qualifierList ] enumLiteral "=" integerValue
+    ///     stringEnumElement      = [ qualifierList ] enumLiteral [ "=" stringValue ]
+    ///
+    ///     enumLiteral            = IDENTIFIER
+    ///
+    /// </remarks>
+    public class EnumElementAst : IAstNode
+    {
+
+        #region Builder
+
+        public sealed class Builder
+        {
+
+            public QualifierListAst Qualifiers
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken EnumElementName
+            {
+                get;
+                set;
+            }
+
+            public IEnumValueAst EnumElementValue
+            {
+                get;
+                set;
+            }
+
+            public EnumElementAst Build()
+            {
+                return new EnumElementAst(
+                    this.Qualifiers,
+                    this.EnumElementName,
+                    this.EnumElementValue
+                );
+            }
+
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public EnumElementAst(QualifierListAst qualifiers, IdentifierToken enumElementName, IEnumValueAst enumElementValue)
+        {
+            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.EnumElementName = enumElementName;
+            this.EnumElementValue = enumElementValue;
+        }
+
+        #endregion
+
+        #region Properties
+
+        public QualifierListAst Qualifiers
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken EnumElementName
+        {
+            get;
+            private set;
+        }
+
+        public IEnumValueAst EnumElementValue
+        {
+            get;
+            private set;
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return MofGenerator.ConvertEnumElementAst(this);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Ast/EnumerationDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/EnumerationDeclarationAst.cs
@@ -1,0 +1,148 @@
+using Kingsland.MofParser.CodeGen;
+using Kingsland.MofParser.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Kingsland.MofParser.Ast
+{
+
+    /// <summary>
+    /// </summary>
+    /// <returns></returns>
+    /// <remarks>
+    ///
+    /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
+    ///
+    /// 7.5.4 Enumeration declaration
+    ///
+    ///     enumerationDeclaration = enumTypeHeader enumName ":" enumTypeDeclaration ";"
+    ///
+    ///     enumTypeHeader         = [ qualifierList ] ENUMERATION
+    ///     enumName               = elementName
+    ///     enumTypeDeclaration    = (DT_INTEGER / integerEnumName ) integerEnumDeclaration /
+    ///                              (DT_STRING / stringEnumName) stringEnumDeclaration
+    ///
+    ///     integerEnumName        = enumName
+    ///     stringEnumName         = enumName
+    ///
+    ///     integerEnumDeclaration = "{" [ integerEnumElement
+    ///                              *( "," integerEnumElement) ] "}"
+    ///     stringEnumDeclaration  = "{" [ stringEnumElement
+    ///                              *( "," stringEnumElement) ] "}"
+    ///
+    ///     integerEnumElement     = [ qualifierList ] enumLiteral "=" integerValue
+    ///     stringEnumElement      = [ qualifierList ] enumLiteral [ "=" stringValue ]
+    ///
+    ///     enumLiteral            = IDENTIFIER
+    ///
+    ///     ENUMERATION            = "enumeration" ; keyword: case insensitive
+    ///
+    /// </remarks>
+    public sealed class EnumerationDeclarationAst : MofProductionAst, IStructureFeatureAst
+    {
+
+        #region Builder
+
+        public sealed class Builder
+        {
+
+            public Builder()
+            {
+                this.EnumElements = new List<EnumElementAst>();
+            }
+
+            public QualifierListAst Qualifiers
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken EnumName
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken EnumType
+            {
+                get;
+                set;
+            }
+
+            public List<EnumElementAst> EnumElements
+            {
+                get;
+                set;
+            }
+
+            public EnumerationDeclarationAst Build()
+            {
+                return new EnumerationDeclarationAst(
+                    this.Qualifiers,
+                    this.EnumName,
+                    this.EnumType,
+                    new ReadOnlyCollection<EnumElementAst>(
+                        this.EnumElements ?? new List<EnumElementAst>()
+                    )
+                );
+            }
+
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public EnumerationDeclarationAst(QualifierListAst qualifiers, IdentifierToken enumName, IdentifierToken enumType, ReadOnlyCollection<EnumElementAst> enumElements)
+        {
+            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.EnumName = enumName ?? throw new ArgumentNullException(nameof(enumName));
+            this.EnumType = enumType ?? throw new ArgumentNullException(nameof(enumType));
+            this.EnumElements = enumElements ?? new ReadOnlyCollection<EnumElementAst>(
+                new List<EnumElementAst>()
+            );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public QualifierListAst Qualifiers
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken EnumName
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken EnumType
+        {
+            get;
+            private set;
+        }
+
+        public ReadOnlyCollection<EnumElementAst> EnumElements
+        {
+            get;
+            private set;
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return MofGenerator.ConvertEnumerationDeclarationAst(this);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Ast/IAstNode.cs
+++ b/src/Kingsland.MofParser/Ast/IAstNode.cs
@@ -1,0 +1,8 @@
+﻿namespace Kingsland.MofParser.Ast
+{
+
+    public interface IAstNode
+    {
+    }
+
+}

--- a/src/Kingsland.MofParser/Ast/IClassFeatureAst.cs
+++ b/src/Kingsland.MofParser/Ast/IClassFeatureAst.cs
@@ -16,16 +16,8 @@ namespace Kingsland.MofParser.Ast
     ///                        propertyDeclaration
     ///
     /// </remarks>
-    public abstract class ClassFeatureAst : AstNode
+    public interface IClassFeatureAst : IAstNode
     {
-
-        #region Constructors
-
-        protected ClassFeatureAst()
-        {
-        }
-
-        #endregion
 
     }
 

--- a/src/Kingsland.MofParser/Ast/IEnumValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/IEnumValueAst.cs
@@ -1,0 +1,22 @@
+namespace Kingsland.MofParser.Ast
+{
+
+    /// <summary>
+    /// </summary>
+    /// <returns></returns>
+    /// <remarks>
+    ///
+    /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
+    ///
+    /// 7.5.4 Enumeration declaration
+    ///
+    ///     integerEnumElement     = [ qualifierList ] enumLiteral "=" integerValue
+    ///     stringEnumElement      = [ qualifierList ] enumLiteral [ "=" stringValue ]
+    ///
+    /// </remarks>
+    public interface IEnumValueAst : IAstNode
+    {
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Ast/IStructureFeatureAst.cs
+++ b/src/Kingsland.MofParser/Ast/IStructureFeatureAst.cs
@@ -14,16 +14,8 @@
     ///                        propertyDeclaration
     ///
     /// </remarks>
-    public abstract class StructureFeatureAst : ClassFeatureAst
+    public interface IStructureFeatureAst : IClassFeatureAst
     {
-
-        #region Constructors
-
-        protected StructureFeatureAst()
-        {
-        }
-
-        #endregion
 
     }
 

--- a/src/Kingsland.MofParser/Ast/IntegerValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/IntegerValueAst.cs
@@ -18,7 +18,7 @@ namespace Kingsland.MofParser.Ast
     ///     integerValue = binaryValue / octalValue / hexValue / decimalValue
     ///
     /// </remarks>
-    public sealed class IntegerValueAst : LiteralValueAst
+    public sealed class IntegerValueAst : LiteralValueAst, IEnumValueAst
     {
 
         #region Builder

--- a/src/Kingsland.MofParser/Ast/LiteralValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/LiteralValueAst.cs
@@ -23,7 +23,7 @@
 
         #region Constructors
 
-        protected LiteralValueAst()
+        internal LiteralValueAst()
         {
         }
 

--- a/src/Kingsland.MofParser/Ast/MethodDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/MethodDeclarationAst.cs
@@ -34,7 +34,7 @@ namespace Kingsland.MofParser.Ast
     ///
     ///    array             = "[" "]"
     ///
-    public sealed class MethodDeclarationAst : ClassFeatureAst
+    public sealed class MethodDeclarationAst : AstNode, IClassFeatureAst
     {
 
         #region Builder

--- a/src/Kingsland.MofParser/Ast/PropertyDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/PropertyDeclarationAst.cs
@@ -38,7 +38,7 @@ namespace Kingsland.MofParser.Ast
     ///     DT_REFERENCE                 = className REF
     ///     REF                          = "ref" ; keyword: case insensitive
     ///
-    public sealed class PropertyDeclarationAst : StructureFeatureAst
+    public sealed class PropertyDeclarationAst : AstNode, IStructureFeatureAst
     {
 
         #region Builder

--- a/src/Kingsland.MofParser/Ast/PropertyValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/PropertyValueAst.cs
@@ -33,6 +33,14 @@ namespace Kingsland.MofParser.Ast
     public abstract class PropertyValueAst : AstNode
     {
 
+        #region Constructors
+
+        internal PropertyValueAst()
+        {
+        }
+
+        #endregion
+
     }
 
 }

--- a/src/Kingsland.MofParser/Ast/StringValueAst.cs
+++ b/src/Kingsland.MofParser/Ast/StringValueAst.cs
@@ -55,7 +55,7 @@ namespace Kingsland.MofParser.Ast
     ///     UNDERSCORE  = U+005F ; _
     ///
     /// </remarks>
-    public sealed class StringValueAst : LiteralValueAst
+    public sealed class StringValueAst : LiteralValueAst, IEnumValueAst
     {
 
         #region Builder

--- a/src/Kingsland.MofParser/Ast/StructureDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/StructureDeclarationAst.cs
@@ -1,0 +1,135 @@
+using Kingsland.MofParser.CodeGen;
+using Kingsland.MofParser.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Kingsland.MofParser.Ast
+{
+
+    /// <summary>
+    /// </summary>
+    /// <remarks>
+    ///
+    /// See https://www.dmtf.org/sites/default/files/standards/documents/DSP0221_3.0.1.pdf
+    ///
+    /// 7.5.1 Structure declaration
+    ///
+    ///     structureDeclaration = [ qualifierList ] STRUCTURE structureName
+    ///                            [ superStructure ]
+    ///                            "{" *structureFeature "}" ";"
+    ///
+    ///     structureName        = elementName
+    ///     superStructure       = ":" structureName
+    ///     structureFeature     = structureDeclaration / ; local structure
+    ///                            enumerationDeclaration / ; local enumeration
+    ///                            propertyDeclaration
+    ///
+    ///     STRUCTURE            = "structure" ; keyword: case insensitive
+    ///
+    /// </remarks>
+    public sealed class StructureDeclarationAst : MofProductionAst, IStructureFeatureAst
+    {
+
+        #region Builder
+
+        public sealed class Builder
+        {
+
+            public Builder()
+            {
+                this.Features = new List<IStructureFeatureAst>();
+            }
+
+            public QualifierListAst Qualifiers
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken StructureName
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken SuperStructure
+            {
+                get;
+                set;
+            }
+
+            public List<IStructureFeatureAst> Features
+            {
+                get;
+                set;
+            }
+
+            public StructureDeclarationAst Build()
+            {
+                return new StructureDeclarationAst(
+                    this.Qualifiers,
+                    this.StructureName,
+                    this.SuperStructure,
+                    new ReadOnlyCollection<IStructureFeatureAst>(
+                        this.Features ?? new List<IStructureFeatureAst>()
+                    )
+                );
+            }
+
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public StructureDeclarationAst(QualifierListAst qualifiers, IdentifierToken structureName, IdentifierToken superStructure, ReadOnlyCollection<IStructureFeatureAst> features)
+        {
+            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.StructureName = structureName ?? throw new ArgumentNullException(nameof(structureName));
+            this.SuperStructure = superStructure;
+            this.Features = features ?? new ReadOnlyCollection<IStructureFeatureAst>(new List<IStructureFeatureAst>());
+        }
+
+        #endregion
+
+        #region Properties
+
+        public QualifierListAst Qualifiers
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken StructureName
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken SuperStructure
+        {
+            get;
+            private set;
+        }
+
+        public ReadOnlyCollection<IStructureFeatureAst> Features
+        {
+            get;
+            private set;
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return MofGenerator.ConvertStructureDeclarationAst(this);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Ast/StructureValueDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/StructureValueDeclarationAst.cs
@@ -31,9 +31,16 @@ namespace Kingsland.MofParser.Ast
         public sealed class Builder
         {
 
-            public Builder()
+            public IdentifierToken Value
             {
-                this.PropertyValues = new List<PropertyValueAst>();
+                get;
+                set;
+            }
+
+            public IdentifierToken Of
+            {
+                get;
+                set;
             }
 
             public IdentifierToken TypeName
@@ -42,13 +49,25 @@ namespace Kingsland.MofParser.Ast
                 set;
             }
 
-            public IdentifierToken Alias
+            public IdentifierToken As
             {
                 get;
                 set;
             }
 
-            public List<PropertyValueAst> PropertyValues
+            public AliasIdentifierToken Alias
+            {
+                get;
+                set;
+            }
+
+            public PropertyValueListAst PropertyValues
+            {
+                get;
+                set;
+            }
+
+            public StatementEndToken StatementEnd
             {
                 get;
                 set;
@@ -57,11 +76,13 @@ namespace Kingsland.MofParser.Ast
             public StructureValueDeclarationAst Build()
             {
                 return new StructureValueDeclarationAst(
-                    this.TypeName,
-                    this.Alias,
-                    new ReadOnlyCollection<PropertyValueAst>(
-                        this.PropertyValues ?? new List<PropertyValueAst>()
-                    )
+                    value: this.Value,
+                    of: this.Of,
+                    typeName: this.TypeName,
+                    @as: this.As,
+                    alias: this.Alias,
+                    propertyValues: this.PropertyValues,
+                    statementEnd: this.StatementEnd
                 );
             }
 
@@ -72,21 +93,43 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         public StructureValueDeclarationAst(
+            IdentifierToken value,
+            IdentifierToken of,
             IdentifierToken typeName,
-            IdentifierToken alias,
-            ReadOnlyCollection<PropertyValueAst> propertyValues
+            IdentifierToken @as,
+            AliasIdentifierToken alias,
+            PropertyValueListAst propertyValues,
+            StatementEndToken statementEnd
         )
         {
+            this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            this.Of = of ?? throw new ArgumentNullException(nameof(of));
             this.TypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
-            this.Alias = alias ?? throw new ArgumentNullException(nameof(alias));
-            this.PropertyValues = propertyValues ?? new ReadOnlyCollection<PropertyValueAst>(
-                new List<PropertyValueAst>()
+            this.As = @as;
+            this.Alias = alias;
+            this.PropertyValues = propertyValues ?? new PropertyValueListAst(
+                new ReadOnlyDictionary<string, PropertyValueAst>(
+                    new Dictionary<string, PropertyValueAst>()
+                )
             );
+            this.StatementEnd = statementEnd ?? throw new ArgumentNullException(nameof(statementEnd));
         }
 
         #endregion
 
         #region Properties
+
+        public IdentifierToken Value
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken Of
+        {
+            get;
+            private set;
+        }
 
         public IdentifierToken TypeName
         {
@@ -94,13 +137,25 @@ namespace Kingsland.MofParser.Ast
             private set;
         }
 
-        public IdentifierToken Alias
+        public IdentifierToken As
         {
             get;
             private set;
         }
 
-        public ReadOnlyCollection<PropertyValueAst> PropertyValues
+        public AliasIdentifierToken Alias
+        {
+            get;
+            private set;
+        }
+
+        public PropertyValueListAst PropertyValues
+        {
+            get;
+            private set;
+        }
+
+        public StatementEndToken StatementEnd
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/_AstNode.cs
+++ b/src/Kingsland.MofParser/Ast/_AstNode.cs
@@ -1,12 +1,16 @@
 ﻿namespace Kingsland.MofParser.Ast
 {
 
-    public abstract class AstNode
+    public abstract class AstNode: IAstNode
     {
+
+        #region Constructors
 
         internal AstNode()
         {
         }
+
+        #endregion
 
     }
 

--- a/src/Kingsland.MofParser/AstNodeDiagram.cd
+++ b/src/Kingsland.MofParser/AstNodeDiagram.cd
@@ -6,6 +6,7 @@
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>Ast\_AstNode.cs</FileName>
     </TypeIdentifier>
+    <Lollipop Position="0.2" />
   </Class>
   <Class Name="Kingsland.MofParser.Ast.ComplexTypeValueAst" Collapsed="true">
     <Position X="9.75" Y="3" Width="1.5" />
@@ -16,13 +17,6 @@
   </Class>
   <Class Name="Kingsland.MofParser.Ast.LiteralValueArrayAst" Collapsed="true">
     <Position X="5.75" Y="4.25" Width="1.5" />
-    <NestedTypes>
-      <Class Name="Kingsland.MofParser.Ast.LiteralValueArrayAst.Builder" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>Ast\LiteralValueArrayAst.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Class>
-    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAgAAAAAAA=</HashCode>
       <FileName>Ast\LiteralValueArrayAst.cs</FileName>
@@ -102,7 +96,7 @@
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAgAAAAAAA=</HashCode>
+      <HashCode>AAAAAAAAAABAAAAEAAAAAAAAAAAAAAAAAAAgAAAAAAA=</HashCode>
       <FileName>Ast\IntegerValueAst.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -160,7 +154,7 @@
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAgAAAAAAA=</HashCode>
+      <HashCode>AAAAAAAAAAAAAAAEAAAAAQAAAAAAAAAAAAAgAAAAAAA=</HashCode>
       <FileName>Ast\StringValueAst.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -206,34 +200,21 @@
       <FileName>Ast\CompilerDirectiveAst.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Kingsland.MofParser.Ast.ClassFeatureAst" Collapsed="true">
-    <Position X="14.75" Y="1.75" Width="1.5" />
-    <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
-      <FileName>Ast\ClassFeatureAst.cs</FileName>
-    </TypeIdentifier>
-  </Class>
   <Class Name="Kingsland.MofParser.Ast.MethodDeclarationAst" Collapsed="true">
-    <Position X="13.75" Y="3" Width="1.5" />
-    <InheritanceLine Type="Kingsland.MofParser.Ast.ClassFeatureAst" FixedToPoint="true">
-      <Path>
-        <Point X="15.5" Y="2.441" />
-        <Point X="15.5" Y="2.7" />
-        <Point X="14.5" Y="2.7" />
-        <Point X="14.5" Y="3" />
-      </Path>
-    </InheritanceLine>
+    <Position X="12.5" Y="1.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AUAAAAAAAAAAAAAEAAAAAAQAAAAAAAAAAIAAAAAEAAA=</HashCode>
+      <HashCode>AUAAAAAAAAAAAAAEAAAAAAQAABAAAAAAAIAAAABEAAA=</HashCode>
       <FileName>Ast\MethodDeclarationAst.cs</FileName>
     </TypeIdentifier>
+    <Lollipop Position="0.2" />
   </Class>
   <Class Name="Kingsland.MofParser.Ast.PropertyDeclarationAst" Collapsed="true">
-    <Position X="15.75" Y="4" Width="1.5" />
+    <Position X="14.5" Y="1.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AEAAAAAAAACAAAAEAAAAAAAAAAgAAAAAAAAAAABEBAA=</HashCode>
+      <HashCode>AUAAAAAAAAAAAAAEAAAAAAAAABAAAAAAAAAAAABEBAA=</HashCode>
       <FileName>Ast\PropertyDeclarationAst.cs</FileName>
     </TypeIdentifier>
+    <Lollipop Position="0.2" />
   </Class>
   <Class Name="Kingsland.MofParser.Ast.QualifierListAst" Collapsed="true">
     <Position X="4.5" Y="1.75" Width="1.5" />
@@ -245,15 +226,8 @@
   <Class Name="Kingsland.MofParser.Ast.ParameterDeclarationAst" Collapsed="true">
     <Position X="6.5" Y="1.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AEAAAAAAAACAAAAEAAAAAAQAAAhAAAAAAQAAAAAAAAA=</HashCode>
+      <HashCode>AEAAAAAAAABAAIAEAgAAAAAAAABAABAAAAAAAAgAAAA=</HashCode>
       <FileName>Ast\ParameterDeclarationAst.cs</FileName>
-    </TypeIdentifier>
-  </Class>
-  <Class Name="Kingsland.MofParser.Ast.StructureFeatureAst" Collapsed="true">
-    <Position X="15.75" Y="3" Width="1.5" />
-    <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
-      <FileName>Ast\StructureFeatureAst.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Kingsland.MofParser.Ast.InstanceValueDeclarationAst" Collapsed="true">
@@ -266,7 +240,7 @@
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAIAAAAEAAAAAAAAAACAABAAAAAAAAAAAAA=</HashCode>
+      <HashCode>AAAAAIAAAAIAAAAEAAAAAAAAAACAQBAAQAAAAAAAAAA=</HashCode>
       <FileName>Ast\InstanceValueDeclarationAst.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -301,9 +275,30 @@
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAEAAAAABQAAAAAAAAAAAAAAAAABAA=</HashCode>
+      <HashCode>AEAAAAAAAAAAAAAEAAAAABQAAAAAAAAAAAAAAAAABAA=</HashCode>
       <FileName>Ast\QualifierTypeDeclarationAst.cs</FileName>
     </TypeIdentifier>
   </Class>
+  <Interface Name="Kingsland.MofParser.Ast.IClassFeatureAst" Collapsed="true">
+    <Position X="16.5" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Ast\IClassFeatureAst.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Kingsland.MofParser.Ast.IAstNode" Collapsed="true">
+    <Position X="16.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Ast\IAstNode.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Kingsland.MofParser.Ast.IStructureFeatureAst" Collapsed="true">
+    <Position X="16.5" Y="2.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Ast\IStructureFeatureAst.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
   <Font Name="Segoe UI" Size="9" />
 </ClassDiagram>

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -652,7 +652,34 @@ namespace Kingsland.MofParser.CodeGen
 
         public static string ConvertStructureValueDeclarationAst(StructureValueDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
-            throw new NotImplementedException();
+            // value of GOLF_PhoneNumber as $JohnDoesPhoneNo
+            // {
+            //     AreaCode = { "9", "0", "7" };
+            //     Number = { "7", "4", "7", "4", "8", "8", "4" };
+            // };
+            var source = new StringBuilder();
+            // value of GOLF_PhoneNumber as $JohnDoesPhoneNo
+            source.Append(node.Value.Extent.Text);
+            source.Append(" ");
+            source.Append(node.Of.Extent.Text);
+            source.Append(" ");
+            source.Append(node.TypeName.Name);
+            if (node.Alias != null)
+            {
+                source.Append(" ");
+                source.Append(node.As.Extent.Text);
+                source.Append(" $");
+                source.Append(node.Alias.Name);
+            }
+            source.AppendLine();
+            // {
+            //     AreaCode = { "9", "0", "7" };
+            //     Number = { "7", "4", "7", "4", "8", "8", "4" };
+            // }
+            source.Append(MofGenerator.ConvertPropertyValueListAst(node.PropertyValues));
+            // ;
+            source.Append(node.StatementEnd.Extent.Text);
+            return source.ToString();
         }
 
         #endregion

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -114,7 +114,8 @@ namespace Kingsland.MofParser.CodeGen
                     return MofGenerator.ConvertStructureDeclarationAst(ast, quirks);
                 case ClassDeclarationAst ast:
                     return MofGenerator.ConvertClassDeclarationAst(ast, quirks);
-                //case AssociationDeclarationAst ast:
+                case AssociationDeclarationAst ast:
+                    return MofGenerator.ConvertAssociationDeclarationAst(ast, quirks);
                 //case EnumerationDeclarationAst ast:
                 case InstanceValueDeclarationAst ast:
                     return MofGenerator.ConvertInstanceValueDeclarationAst(ast, quirks);
@@ -301,9 +302,9 @@ namespace Kingsland.MofParser.CodeGen
                 source.Append(indent);
             }
             source.Append($"{Constants.CLASS} {node.ClassName.Name}");
-            if (node.Superclass != null)
+            if (node.SuperClass != null)
             {
-                source.Append($" : {node.Superclass.Name}");
+                source.Append($" : {node.SuperClass.Name}");
             }
             source.AppendLine();
             source.Append(indent);
@@ -331,6 +332,37 @@ namespace Kingsland.MofParser.CodeGen
                 default:
                     throw new NotImplementedException();
             }
+        }
+
+        #endregion
+
+        #region 7.5.3 Association declaration
+
+        public static string ConvertAssociationDeclarationAst(AssociationDeclarationAst node, MofQuirks quirks = MofQuirks.None, string indent = "")
+        {
+            var source = new StringBuilder();
+            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            {
+                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(indent);
+            }
+            source.Append($"{Constants.ASSOCIATION} {node.AssociationName.Name}");
+            if (node.SuperAssociation != null)
+            {
+                source.Append($" : {node.SuperAssociation.Name}");
+            }
+            source.AppendLine();
+            source.Append(indent);
+            source.AppendLine("{");
+            foreach (var feature in node.Features)
+            {
+                source.Append(indent);
+                source.Append("\t");
+                source.AppendLine(MofGenerator.ConvertClassFeatureAst(feature, quirks, indent + '\t'));
+            }
+            source.Append(indent);
+            source.Append("};");
+            return source.ToString();
         }
 
         #endregion

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -570,9 +570,10 @@ namespace Kingsland.MofParser.CodeGen
 
         internal static string EscapeString(string value)
         {
-            var escapeMap = new Dictionary<char, char>()
+            var escapeMap = new Dictionary<char, string>()
             {
-                { '\\' , '\\' }, { '\"' , '\"' },  {'\b', 'b'}, {'\t', 't'},  {'\n', 'n'}, {'\f', 'f'}, {'\r', 'r'}
+                { '\\' , "\\\\" }, { '\"' , "\\\"" },  { '\'' , "\\\'" },
+                { '\b', "\\b" }, { '\t', "\\t" },  { '\n', "\\n" }, { '\f', "\\f" }, { '\r', "\\r" }
             };
             if (string.IsNullOrEmpty(value))
             {
@@ -583,7 +584,7 @@ namespace Kingsland.MofParser.CodeGen
             {
                 if (escapeMap.ContainsKey(@char))
                 {
-                    escaped.AppendFormat("\\{0}", escapeMap[@char]);
+                    escaped.Append(escapeMap[@char]);
                 }
                 else if ((@char >= 32) && (@char <= 126))
                 {

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -135,7 +135,7 @@ namespace Kingsland.MofParser.CodeGen
 
         public static string ConvertCompilerDirectiveAst(CompilerDirectiveAst node, MofQuirks quirks = MofQuirks.None)
         {
-            return string.Format("!!!!!{0}!!!!!", node.GetType().Name);
+            return $"!!!!!{node.GetType().Name}!!!!!";
         }
 
         #endregion
@@ -153,7 +153,9 @@ namespace Kingsland.MofParser.CodeGen
             {
                 if (node.Initializer is LiteralValueAst)
                 {
-                    source.AppendFormat("({0})", MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
+                    source.Append("(");
+                    source.Append(MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
+                    source.Append(")");
                 }
                 else if (node.Initializer is LiteralValueArrayAst)
                 {
@@ -166,7 +168,8 @@ namespace Kingsland.MofParser.CodeGen
             }
             if (node.Flavors.Count > 0)
             {
-                source.AppendFormat(": {0}", string.Join(" ", node.Flavors.ToArray()));
+                source.Append(": ");
+                source.Append(string.Join(" ", node.Flavors.ToArray()));
             }
             return source.ToString();
         }
@@ -439,12 +442,15 @@ namespace Kingsland.MofParser.CodeGen
             var source = new StringBuilder();
             if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendFormat("{0} ", MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(" ");
             }
-            source.AppendFormat("{0} ", node.ReturnType.Name);
+            source.Append(node.ReturnType.Name);
+            source.Append(" ");
             if (node.ReturnTypeIsRef)
             {
-                source.AppendFormat("{0} ", node.ReturnTypeRef.Name);
+                source.Append(node.ReturnTypeRef.Name);
+                source.Append(" ");
             }
             source.Append(node.PropertyName.Name);
             if (node.ReturnTypeIsArray)
@@ -453,7 +459,8 @@ namespace Kingsland.MofParser.CodeGen
             }
             if (node.Initializer != null)
             {
-                source.AppendFormat(" = {0}", MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
+                source.Append(" = ");
+                source.Append(MofGenerator.ConvertPrimitiveTypeValueAst(node.Initializer, quirks));
             }
             source.Append(";");
             return source.ToString();
@@ -472,15 +479,15 @@ namespace Kingsland.MofParser.CodeGen
 
             if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendFormat("{0}", MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
             }
 
             if (prefixQuirkEnabled || ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0))
             {
-                source.AppendFormat(" ");
+                source.Append(" ");
             }
 
-            source.AppendFormat("{0} {1}", node.ReturnType.Name, node.Name.Name);
+            source.Append($"{node.ReturnType.Name} {node.Name.Name}");
 
             if (node.Parameters.Count == 0)
             {
@@ -489,7 +496,9 @@ namespace Kingsland.MofParser.CodeGen
             else
             {
                 var values = node.Parameters.Select(p => MofGenerator.ConvertParameterDeclarationAst(p, quirks)).ToArray();
-                source.AppendFormat("({0});", string.Join(", ", values));
+                source.Append("(");
+                source.Append(string.Join(", ", values));
+                source.Append(");");
             }
 
             return source.ToString();
@@ -505,12 +514,15 @@ namespace Kingsland.MofParser.CodeGen
             var source = new StringBuilder();
             if (node.Qualifiers.Qualifiers.Count > 0)
             {
-                source.AppendFormat("{0} ", MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(" ");
             }
-            source.AppendFormat("{0} ", node.ParameterType.Name);
+            source.Append(node.ParameterType.Name);
+            source.Append(" ");
             if (node.ParameterIsRef)
             {
-                source.AppendFormat("{0} ", node.ParameterRef.Name);
+                source.Append(node.ParameterRef.Name);
+                source.Append(" ");
             }
             source.Append(node.ParameterName.Name);
             if (node.ParameterIsArray)
@@ -519,7 +531,8 @@ namespace Kingsland.MofParser.CodeGen
             }
             if (node.DefaultValue != null)
             {
-                source.AppendFormat(" = {0}", MofGenerator.ConvertToMof(node.DefaultValue, quirks));
+                source.Append(" = ");
+                source.Append(MofGenerator.ConvertToMof(node.DefaultValue, quirks));
             }
             return source.ToString();
         }
@@ -658,8 +671,16 @@ namespace Kingsland.MofParser.CodeGen
 
         public static string ConvertLiteralValueArrayAst(LiteralValueArrayAst node, MofQuirks quirks = MofQuirks.None)
         {
-            var values = node.Values.Select(v => MofGenerator.ConvertLiteralValueAst(v, quirks)).ToArray();
-            return string.Format("{{{0}}}", string.Join(", ", values));
+            var source = new StringBuilder();
+            source.Append("{");
+            source.Append(
+                string.Join(
+                    ", ",
+                    node.Values.Select(v => MofGenerator.ConvertLiteralValueAst(v, quirks))
+                )
+            );
+            source.Append("}");
+            return source.ToString();
         }
 
         #endregion
@@ -698,10 +719,11 @@ namespace Kingsland.MofParser.CodeGen
 
         public static string ConvertStringValueAst(StringValueAst node, MofQuirks quirks = MofQuirks.None)
         {
-            var singleStringValues = node.StringLiteralValues
-                                         .Select(n => $"\"{MofGenerator.EscapeString(n.Value)}\"")
-                                         .ToList();
-            return string.Join(" ", singleStringValues);
+            return string.Join(
+                " ",
+                node.StringLiteralValues
+                    .Select(n => $"\"{MofGenerator.EscapeString(n.Value)}\"")
+            );
         }
 
         internal static string EscapeString(string value)
@@ -724,6 +746,7 @@ namespace Kingsland.MofParser.CodeGen
                 }
                 else if ((@char >= 32) && (@char <= 126))
                 {
+                    // printable characters ' ' - '~'
                     escaped.Append(@char);
                 }
                 else

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -463,7 +463,7 @@ namespace Kingsland.MofParser.CodeGen
             source.AppendLine("{");
             foreach (var propertyValue in node.PropertyValues)
             {
-                source.AppendLine($"    {propertyValue.Key} = {MofGenerator.ConvertPropertyValueAst(propertyValue.Value)};");
+                source.AppendLine($"\t{propertyValue.Key} = {MofGenerator.ConvertPropertyValueAst(propertyValue.Value)};");
             }
             source.Append("}");
             return source.ToString();

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -116,7 +116,8 @@ namespace Kingsland.MofParser.CodeGen
                     return MofGenerator.ConvertClassDeclarationAst(ast, quirks);
                 case AssociationDeclarationAst ast:
                     return MofGenerator.ConvertAssociationDeclarationAst(ast, quirks);
-                //case EnumerationDeclarationAst ast:
+                case EnumerationDeclarationAst ast:
+                    return MofGenerator.ConvertEnumerationDeclarationAst(ast, quirks);
                 case InstanceValueDeclarationAst ast:
                     return MofGenerator.ConvertInstanceValueDeclarationAst(ast, quirks);
                 case StructureValueDeclarationAst ast:
@@ -281,7 +282,8 @@ namespace Kingsland.MofParser.CodeGen
             {
                 case StructureDeclarationAst ast:
                     return MofGenerator.ConvertStructureDeclarationAst(ast, quirks, indent);
-                //case EnumerationDeclarationAst ast:
+                case EnumerationDeclarationAst ast:
+                    return MofGenerator.ConvertEnumerationDeclarationAst(ast, quirks, indent);
                 case PropertyDeclarationAst ast:
                     return MofGenerator.ConvertPropertyDeclarationAst(ast, quirks);
                 default:
@@ -363,6 +365,69 @@ namespace Kingsland.MofParser.CodeGen
             source.Append(indent);
             source.Append("};");
             return source.ToString();
+        }
+
+        #endregion
+
+        #region 7.5.4 Enumeration declaration
+
+        public static string ConvertEnumerationDeclarationAst(EnumerationDeclarationAst node, MofQuirks quirks = MofQuirks.None, string indent = "")
+        {
+            var source = new StringBuilder();
+            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            {
+                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(indent);
+            }
+            source.Append($"{Constants.ENUMERATION} {node.EnumName.Name}");
+            source.Append($" : {node.EnumType.Name}");
+            source.AppendLine();
+            source.Append(indent);
+            source.AppendLine("{");
+            for (var i = 0; i < node.EnumElements.Count; i++)
+            {
+                source.Append(indent);
+                source.Append("\t");
+                source.Append(MofGenerator.ConvertEnumElementAst(node.EnumElements[i], quirks));
+                if (i < (node.EnumElements.Count - 1))
+                {
+                    source.Append(",");
+                }
+                source.AppendLine();
+            }
+            source.Append(indent);
+            source.Append("};");
+            return source.ToString();
+        }
+
+        public static string ConvertEnumElementAst(EnumElementAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            var source = new StringBuilder();
+            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            {
+                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(" ");
+            }
+            source.Append(node.EnumElementName.Name);
+            if (node.EnumElementValue != null)
+            {
+                source.Append(" = ");
+                source.Append(MofGenerator.ConvertIEnumValueAst(node.EnumElementValue, quirks));
+            }
+            return source.ToString();
+        }
+
+        public static string ConvertIEnumValueAst(IEnumValueAst node, MofQuirks quirks = MofQuirks.None)
+        {
+            switch (node)
+            {
+                case IntegerValueAst ast:
+                    return MofGenerator.ConvertIntegerValueAst(ast, quirks);
+                case StringValueAst ast:
+                    return MofGenerator.ConvertStringValueAst(ast, quirks);
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         #endregion

--- a/src/Kingsland.MofParser/Kingsland.MofParser.csproj
+++ b/src/Kingsland.MofParser/Kingsland.MofParser.csproj
@@ -32,7 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Ast\AssociationDeclarationAst.cs" />
+    <Compile Include="Ast\EnumerationDeclarationAst.cs" />
     <Compile Include="Ast\IAstNode.cs" />
+    <Compile Include="Ast\EnumElementAst.cs" />
+    <Compile Include="Ast\IEnumValueAst.cs" />
     <Compile Include="Ast\StructureDeclarationAst.cs" />
     <Compile Include="Ast\ClassDeclarationAst.cs" />
     <Compile Include="Ast\ComplexTypeValueAst.cs" />

--- a/src/Kingsland.MofParser/Kingsland.MofParser.csproj
+++ b/src/Kingsland.MofParser/Kingsland.MofParser.csproj
@@ -31,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Ast\AssociationDeclarationAst.cs" />
     <Compile Include="Ast\IAstNode.cs" />
     <Compile Include="Ast\StructureDeclarationAst.cs" />
     <Compile Include="Ast\ClassDeclarationAst.cs" />

--- a/src/Kingsland.MofParser/Kingsland.MofParser.csproj
+++ b/src/Kingsland.MofParser/Kingsland.MofParser.csproj
@@ -31,12 +31,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Ast\IAstNode.cs" />
+    <Compile Include="Ast\StructureDeclarationAst.cs" />
     <Compile Include="Ast\ClassDeclarationAst.cs" />
     <Compile Include="Ast\ComplexTypeValueAst.cs" />
     <Compile Include="Tokens\IntegerKind.cs" />
     <Compile Include="Ast\PropertyValueListAst.cs" />
     <Compile Include="Ast\QualifierValueAst.cs" />
-    <Compile Include="Ast\StructureFeatureAst.cs" />
+    <Compile Include="Ast\IStructureFeatureAst.cs" />
     <Compile Include="Ast\StructureValueDeclarationAst.cs" />
     <Compile Include="Ast\InstanceValueDeclarationAst.cs" />
     <Compile Include="Ast\ComplexValueArrayAst.cs" />
@@ -46,7 +48,7 @@
     <Compile Include="Ast\PropertyDeclarationAst.cs" />
     <Compile Include="Ast\LiteralValueArrayAst.cs" />
     <Compile Include="Ast\LiteralValueAst.cs" />
-    <Compile Include="Ast\ClassFeatureAst.cs" />
+    <Compile Include="Ast\IClassFeatureAst.cs" />
     <Compile Include="Ast\MethodDeclarationAst.cs" />
     <Compile Include="Ast\NullValueAst.cs" />
     <Compile Include="Ast\CompilerDirectiveAst.cs" />

--- a/src/Kingsland.MofParser/Parsing/ParserEngine.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserEngine.cs
@@ -111,8 +111,7 @@ namespace Kingsland.MofParser.Parsing
                 return ParserEngine.ParseCompilerDirectiveAst(stream);
             }
 
-            var identifier = stream.Peek<IdentifierToken>();
-            if (identifier != null)
+            if (peek is IdentifierToken identifier)
             {
                 switch (identifier.GetNormalizedName())
                 {
@@ -277,9 +276,9 @@ namespace Kingsland.MofParser.Parsing
             // [qualifierPolicy]
 
             // ";"
-            stream.Read<StatementEndToken>();
+            //stream.Read<StatementEndToken>();
 
-            return node.Build();
+            //return node.Build();
 
         }
 
@@ -1011,7 +1010,7 @@ namespace Kingsland.MofParser.Parsing
                         throw new UnsupportedTokenException(peek);
                     }
                     stream.Read<EqualsOperatorToken>();
-                    propertyInitializer = ParserEngine.ReadClassFeatureAstDefaultValue(stream, memberReturnType);
+                    propertyInitializer = ParserEngine.ReadClassFeatureAstInitializer(stream, memberReturnType);
                 }
             }
 
@@ -1057,7 +1056,7 @@ namespace Kingsland.MofParser.Parsing
 
         }
 
-        public static PrimitiveTypeValueAst ReadClassFeatureAstDefaultValue(ParserStream stream, IdentifierToken returnType)
+        public static PrimitiveTypeValueAst ReadClassFeatureAstInitializer(ParserStream stream, IdentifierToken returnType)
         {
             switch (returnType.GetNormalizedName())
             {
@@ -1079,7 +1078,7 @@ namespace Kingsland.MofParser.Parsing
                     {
                         return ParserEngine.ParseNullValueAst(stream);
                     }
-                    throw new UnsupportedTokenException(stream.Peek());
+                    throw new NotImplementedException($"classFeature initializer type '{returnType.Name}'");
             }
         }
 
@@ -1406,7 +1405,7 @@ namespace Kingsland.MofParser.Parsing
             if (stream.Peek<EqualsOperatorToken>() != null)
             {
                 stream.Read<EqualsOperatorToken>();
-                parameterDefaultValue = ParserEngine.ReadClassFeatureAstDefaultValue(stream, parameterTypeName);
+                parameterDefaultValue = ParserEngine.ReadClassFeatureAstInitializer(stream, parameterTypeName);
             }
 
             return new ParameterDeclarationAst.Builder {

--- a/src/Kingsland.MofParser/Parsing/ParserEngine.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserEngine.cs
@@ -1816,7 +1816,43 @@ namespace Kingsland.MofParser.Parsing
         /// </remarks>
         public static StructureValueDeclarationAst ParseStructureValueDeclarationAst(ParserStream stream)
         {
-            throw new NotImplementedException();
+
+            var node = new StructureValueDeclarationAst.Builder();
+
+            // VALUE
+            node.Value = stream.ReadIdentifier(Constants.VALUE);
+
+            // OF
+            node.Of = stream.ReadIdentifier(Constants.OF);
+
+            // ( className / associationName / structureName )
+            var nameToken = stream.Read<IdentifierToken>();
+            if (!StringValidator.IsClassName(nameToken.Name) &&
+                !StringValidator.IsAssociationName(nameToken.Name) &&
+                !StringValidator.IsStructureName(nameToken.Name))
+            {
+                throw new InvalidOperationException("Identifer is not a className, associationName or structureName");
+            }
+            node.TypeName = nameToken;
+
+            // [alias]
+            if (stream.PeekIdentifier(Constants.AS))
+            {
+                // AS
+                node.As = stream.ReadIdentifier(Constants.AS);
+                // aliasIdentifier
+                var aliasIdentifierToken = stream.Read<AliasIdentifierToken>();
+                node.Alias = aliasIdentifierToken;
+            }
+
+            // propertyValueList
+            node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream);
+
+            // ";"
+            node.StatementEnd = stream.Read<StatementEndToken>();
+
+            return node.Build();
+
         }
 
 

--- a/src/Kingsland.MofParser/Parsing/ParserEngine.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserEngine.cs
@@ -1273,35 +1273,39 @@ namespace Kingsland.MofParser.Parsing
 
             var node = new ComplexValueAst.Builder();
 
-            // aliasIdentifier
             if (stream.Peek<AliasIdentifierToken>() != null)
             {
-                var aliasIdentifierToken = stream.Read<AliasIdentifierToken>();
-                node.IsAlias = true;
-                node.Alias = aliasIdentifierToken;
-                return node.Build();
+
+                // aliasIdentifier
+                node.Alias = stream.Read<AliasIdentifierToken>();
+
             }
-
-            // VALUE OF
-            var valueKeyword = stream.ReadIdentifier(Constants.VALUE);
-            var ofKeyword = stream.ReadIdentifier(Constants.OF);
-            node.IsValue = true;
-
-            // ( structureName / className / associationName )
-            if (stream.Peek<IdentifierToken>() != null)
+            else
             {
-                var typeName = stream.Read<IdentifierToken>();
-                if (!StringValidator.IsStructureName(typeName.Name) &&
-                    !StringValidator.IsClassName(typeName.Name) &&
-                    !StringValidator.IsAssociationName(typeName.Name))
-                {
-                    throw new InvalidOperationException("Identifer is not a structureName, className or associationName");
-                }
-                node.TypeName = typeName;
-            }
 
-            // propertyValueList
-            node.Properties = ParserEngine.ParsePropertyValueListAst(stream);
+                // VALUE
+                node.Value = stream.ReadIdentifier(Constants.VALUE);
+
+                // OF
+                node.Of = stream.ReadIdentifier(Constants.OF);
+
+                // ( structureName / className / associationName )
+                if (stream.Peek<IdentifierToken>() != null)
+                {
+                    var typeName = stream.Read<IdentifierToken>();
+                    if (!StringValidator.IsStructureName(typeName.Name) &&
+                        !StringValidator.IsClassName(typeName.Name) &&
+                        !StringValidator.IsAssociationName(typeName.Name))
+                    {
+                        throw new InvalidOperationException("Identifer is not a structureName, className or associationName");
+                    }
+                    node.TypeName = typeName;
+                }
+
+                // propertyValueList
+                node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream);
+
+            }
 
             // return the result
             return node.Build();
@@ -1398,7 +1402,8 @@ namespace Kingsland.MofParser.Parsing
             }
             bool IsComplexValueToken(Token token)
             {
-                return (token is AliasIdentifierToken);
+                return (token is AliasIdentifierToken) ||
+                       ((token is IdentifierToken identifier) && (identifier.GetNormalizedName() == Constants.VALUE));
             }
             var node = default(PropertyValueAst);
             var peek = stream.Peek();
@@ -1442,8 +1447,8 @@ namespace Kingsland.MofParser.Parsing
                 }
                 else if (IsComplexValueToken(peek))
                 {
-                    // complexValue
-                    node = ParserEngine.ParseComplexTypeValueAst(stream);
+                    // complexValueArray
+                    node = ParserEngine.ParseComplexValueArrayAst(stream);
                 }
                 else
                 {

--- a/src/Kingsland.MofParser/Parsing/StringValidator.cs
+++ b/src/Kingsland.MofParser/Parsing/StringValidator.cs
@@ -60,7 +60,7 @@ namespace Kingsland.MofParser.Parsing
         /// </summary>
         /// <param name="value"></param>
         /// <remarks>
-        /// className = schemaQualifiedName
+        /// className = elementName
         /// </remarks>
         public static bool IsClassName(string value)
         {
@@ -82,6 +82,25 @@ namespace Kingsland.MofParser.Parsing
         /// associationName = schemaQualifiedName
         /// </remarks>
         public static bool IsAssociationName(string value)
+        {
+            return StringValidator.IsElementName(value);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region 7.5.4 Enumeration declaration
+
+        #region enumName = elementName
+
+        /// <summary>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <remarks>
+        /// enumName = elementName
+        /// </remarks>
+        public static bool IsEnumName(string value)
         {
             return StringValidator.IsElementName(value);
         }


### PR DESCRIPTION
Fixes for the following issues:

+ #18 - structureDeclaration not implemented
+ #19 - structureValueDeclaration not implemented
+ #20 - MofGenerator doesn't escape single quotes
+ #21 - MofGenerator uses spaces instead of tabs in ConvertPropertyValueListAst
+ #22 - associationDeclaration not implemented
+ #23 - enumerationDeclaration not implemented
