### PR TITLE
Renamed Qualifier properties (e.g. Qualifiers => QualifierList)

### DIFF
--- a/src/Kingsland.MofParser/Ast/AssociationDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/AssociationDeclarationAst.cs
@@ -37,7 +37,7 @@ namespace Kingsland.MofParser.Ast
                 this.Features = new List<IClassFeatureAst>();
             }
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -64,7 +64,7 @@ namespace Kingsland.MofParser.Ast
             public AssociationDeclarationAst Build()
             {
                 return new AssociationDeclarationAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.AssociationName,
                     this.SuperAssociation,
                     new ReadOnlyCollection<IClassFeatureAst>(
@@ -79,9 +79,9 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public AssociationDeclarationAst(QualifierListAst qualifiers, IdentifierToken associationName, IdentifierToken superAssociation, ReadOnlyCollection<IClassFeatureAst> features)
+        public AssociationDeclarationAst(QualifierListAst qualifierList, IdentifierToken associationName, IdentifierToken superAssociation, ReadOnlyCollection<IClassFeatureAst> features)
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.AssociationName = associationName ?? throw new ArgumentNullException(nameof(associationName));
             this.SuperAssociation = superAssociation;
             this.Features = features ?? new ReadOnlyCollection<IClassFeatureAst>(new List<IClassFeatureAst>());
@@ -91,7 +91,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/EnumElementAst.cs
+++ b/src/Kingsland.MofParser/Ast/EnumElementAst.cs
@@ -27,7 +27,7 @@ namespace Kingsland.MofParser.Ast
         public sealed class Builder
         {
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -48,7 +48,7 @@ namespace Kingsland.MofParser.Ast
             public EnumElementAst Build()
             {
                 return new EnumElementAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.EnumElementName,
                     this.EnumElementValue
                 );
@@ -60,9 +60,9 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public EnumElementAst(QualifierListAst qualifiers, IdentifierToken enumElementName, IEnumValueAst enumElementValue)
+        public EnumElementAst(QualifierListAst qualifierList, IdentifierToken enumElementName, IEnumValueAst enumElementValue)
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.EnumElementName = enumElementName;
             this.EnumElementValue = enumElementValue;
         }
@@ -71,7 +71,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/EnumerationDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/EnumerationDeclarationAst.cs
@@ -52,7 +52,7 @@ namespace Kingsland.MofParser.Ast
                 this.EnumElements = new List<EnumElementAst>();
             }
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -79,7 +79,7 @@ namespace Kingsland.MofParser.Ast
             public EnumerationDeclarationAst Build()
             {
                 return new EnumerationDeclarationAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.EnumName,
                     this.EnumType,
                     new ReadOnlyCollection<EnumElementAst>(
@@ -94,9 +94,9 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public EnumerationDeclarationAst(QualifierListAst qualifiers, IdentifierToken enumName, IdentifierToken enumType, ReadOnlyCollection<EnumElementAst> enumElements)
+        public EnumerationDeclarationAst(QualifierListAst qualifierList, IdentifierToken enumName, IdentifierToken enumType, ReadOnlyCollection<EnumElementAst> enumElements)
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.EnumName = enumName ?? throw new ArgumentNullException(nameof(enumName));
             this.EnumType = enumType ?? throw new ArgumentNullException(nameof(enumType));
             this.EnumElements = enumElements ?? new ReadOnlyCollection<EnumElementAst>(
@@ -108,7 +108,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/MethodDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/MethodDeclarationAst.cs
@@ -47,7 +47,7 @@ namespace Kingsland.MofParser.Ast
                 this.Parameters = new List<ParameterDeclarationAst>();
             }
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -86,7 +86,7 @@ namespace Kingsland.MofParser.Ast
             public MethodDeclarationAst Build()
             {
                 return new MethodDeclarationAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.ReturnType,
                     this.ReturnTypeRef,
                     this.ReturnTypeIsArray,
@@ -104,7 +104,7 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         private MethodDeclarationAst(
-            QualifierListAst qualifiers,
+            QualifierListAst qualifierList,
             IdentifierToken returnType,
             IdentifierToken returnTypeRef,
             bool returnTypeIsArray,
@@ -112,7 +112,7 @@ namespace Kingsland.MofParser.Ast
             ReadOnlyCollection<ParameterDeclarationAst> parameters
         )
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.ReturnType = returnType ?? throw new ArgumentNullException(nameof(returnType));
             this.ReturnTypeRef = returnTypeRef;
             this.ReturnTypeIsArray = returnTypeIsArray;
@@ -126,7 +126,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/ParameterDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/ParameterDeclarationAst.cs
@@ -42,7 +42,7 @@ namespace Kingsland.MofParser.Ast
         public sealed class Builder
         {
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -81,7 +81,7 @@ namespace Kingsland.MofParser.Ast
             public ParameterDeclarationAst Build()
             {
                 return new ParameterDeclarationAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.ParameterType,
                     this.ParameterRef,
                     this.ParameterName,
@@ -97,7 +97,7 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         private ParameterDeclarationAst(
-            QualifierListAst qualifiers,
+            QualifierListAst qualifierList,
             IdentifierToken parameterType,
             IdentifierToken parameterRef,
             IdentifierToken parameterName,
@@ -105,7 +105,7 @@ namespace Kingsland.MofParser.Ast
             AstNode defaultValue
         )
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.ParameterType = parameterType ?? throw new ArgumentNullException(nameof(parameterType));
             this.ParameterRef = parameterRef;
             this.ParameterName = parameterName ?? throw new ArgumentNullException(nameof(parameterName));
@@ -117,7 +117,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/PropertyDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/PropertyDeclarationAst.cs
@@ -46,7 +46,7 @@ namespace Kingsland.MofParser.Ast
         public sealed class Builder
         {
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -85,7 +85,7 @@ namespace Kingsland.MofParser.Ast
             public PropertyDeclarationAst Build()
             {
                 return new PropertyDeclarationAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.ReturnType,
                     this.ReturnTypeRef,
                     this.PropertyName,
@@ -101,7 +101,7 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         private PropertyDeclarationAst(
-            QualifierListAst qualifiers,
+            QualifierListAst qualifierList,
             IdentifierToken returnType,
             IdentifierToken returnTypeRef,
             IdentifierToken propertyName,
@@ -109,7 +109,7 @@ namespace Kingsland.MofParser.Ast
             PrimitiveTypeValueAst initializer
         )
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.ReturnType = returnType ?? throw new ArgumentNullException(nameof(returnType));
             this.ReturnTypeRef = returnTypeRef;
             this.PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
@@ -121,7 +121,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/QualifierListAst.cs
+++ b/src/Kingsland.MofParser/Ast/QualifierListAst.cs
@@ -28,10 +28,10 @@ namespace Kingsland.MofParser.Ast
 
             public Builder()
             {
-                this.Qualifiers = new List<QualifierValueAst>();
+                this.QualifierValues = new List<QualifierValueAst>();
             }
 
-            public List<QualifierValueAst> Qualifiers
+            public List<QualifierValueAst> QualifierValues
             {
                 get;
                 set;
@@ -41,7 +41,7 @@ namespace Kingsland.MofParser.Ast
             {
                 return new QualifierListAst(
                     new ReadOnlyCollection<QualifierValueAst>(
-                        this.Qualifiers ?? new List<QualifierValueAst>()
+                        this.QualifierValues ?? new List<QualifierValueAst>()
                     )
                 );
             }
@@ -52,9 +52,9 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public QualifierListAst(ReadOnlyCollection<QualifierValueAst> qualifiers)
+        public QualifierListAst(ReadOnlyCollection<QualifierValueAst> qualifierValues)
         {
-            this.Qualifiers = qualifiers ?? new ReadOnlyCollection<QualifierValueAst>(
+            this.QualifierValues = qualifierValues ?? new ReadOnlyCollection<QualifierValueAst>(
                 new List<QualifierValueAst>()
             );
         }
@@ -63,7 +63,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public ReadOnlyCollection<QualifierValueAst> Qualifiers
+        public ReadOnlyCollection<QualifierValueAst> QualifierValues
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/Ast/QualifierTypeDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/QualifierTypeDeclarationAst.cs
@@ -35,13 +35,37 @@ namespace Kingsland.MofParser.Ast
                 this.Flavors = new List<string>();
             }
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
             }
 
-            public IdentifierToken Name
+            public IdentifierToken QualifierKeyword
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken QualifierName
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken QualifierType
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken QualifierScope
+            {
+                get;
+                set;
+            }
+
+            public IdentifierToken QualifierPolicy
             {
                 get;
                 set;
@@ -62,8 +86,12 @@ namespace Kingsland.MofParser.Ast
             public QualifierTypeDeclarationAst Build()
             {
                 return new QualifierTypeDeclarationAst(
-                    this.Qualifiers,
-                    this.Name,
+                    this.QualifierList,
+                    this.QualifierKeyword,
+                    this.QualifierName,
+                    this.QualifierType,
+                    this.QualifierScope,
+                    this.QualifierPolicy,
                     this.Initializer,
                     new ReadOnlyCollection<string>(
                         this.Flavors ?? new List<string>()
@@ -78,14 +106,22 @@ namespace Kingsland.MofParser.Ast
         #region Constructors
 
         private QualifierTypeDeclarationAst(
-            QualifierListAst qualifiers,
-            IdentifierToken name,
+            QualifierListAst qualifierList,
+            IdentifierToken qualifierKeyword,
+            IdentifierToken qualifierName,
+            IdentifierToken qualifierType,
+            IdentifierToken qualifierScope,
+            IdentifierToken qualifierPolicy,
             PrimitiveTypeValueAst initializer,
             ReadOnlyCollection<string> flavors
         )
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
-            this.Name = name ?? throw new ArgumentNullException(nameof(name));
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
+            this.QualifierKeyword = qualifierKeyword ?? throw new ArgumentNullException(nameof(qualifierKeyword));
+            this.QualifierName = qualifierName ?? throw new ArgumentNullException(nameof(qualifierName));
+            this.QualifierType = qualifierType ?? throw new ArgumentNullException(nameof(qualifierType));
+            this.QualifierScope = qualifierScope ?? throw new ArgumentNullException(nameof(qualifierScope));
+            this.QualifierPolicy = qualifierPolicy ?? throw new ArgumentNullException(nameof(qualifierPolicy));
             this.Initializer = initializer ?? throw new ArgumentNullException(nameof(initializer));
             this.Flavors = flavors ?? throw new ArgumentNullException(nameof(flavors));
         }
@@ -94,17 +130,42 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;
         }
 
-        public IdentifierToken Name
+        public IdentifierToken QualifierKeyword
         {
             get;
             private set;
         }
+
+        public IdentifierToken QualifierName
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken QualifierType
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken QualifierScope
+        {
+            get;
+            private set;
+        }
+
+        public IdentifierToken QualifierPolicy
+        {
+            get;
+            private set;
+        }
+
 
         public PrimitiveTypeValueAst Initializer
         {

--- a/src/Kingsland.MofParser/Ast/StructureDeclarationAst.cs
+++ b/src/Kingsland.MofParser/Ast/StructureDeclarationAst.cs
@@ -41,7 +41,7 @@ namespace Kingsland.MofParser.Ast
                 this.Features = new List<IStructureFeatureAst>();
             }
 
-            public QualifierListAst Qualifiers
+            public QualifierListAst QualifierList
             {
                 get;
                 set;
@@ -68,7 +68,7 @@ namespace Kingsland.MofParser.Ast
             public StructureDeclarationAst Build()
             {
                 return new StructureDeclarationAst(
-                    this.Qualifiers,
+                    this.QualifierList,
                     this.StructureName,
                     this.SuperStructure,
                     new ReadOnlyCollection<IStructureFeatureAst>(
@@ -83,9 +83,9 @@ namespace Kingsland.MofParser.Ast
 
         #region Constructors
 
-        public StructureDeclarationAst(QualifierListAst qualifiers, IdentifierToken structureName, IdentifierToken superStructure, ReadOnlyCollection<IStructureFeatureAst> features)
+        public StructureDeclarationAst(QualifierListAst qualifierList, IdentifierToken structureName, IdentifierToken superStructure, ReadOnlyCollection<IStructureFeatureAst> features)
         {
-            this.Qualifiers = qualifiers ?? new QualifierListAst.Builder().Build();
+            this.QualifierList = qualifierList ?? new QualifierListAst.Builder().Build();
             this.StructureName = structureName ?? throw new ArgumentNullException(nameof(structureName));
             this.SuperStructure = superStructure;
             this.Features = features ?? new ReadOnlyCollection<IStructureFeatureAst>(new List<IStructureFeatureAst>());
@@ -95,7 +95,7 @@ namespace Kingsland.MofParser.Ast
 
         #region Properties
 
-        public QualifierListAst Qualifiers
+        public QualifierListAst QualifierList
         {
             get;
             private set;

--- a/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
+++ b/src/Kingsland.MofParser/CodeGen/MofGenerator.cs
@@ -153,9 +153,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertQualifierTypeDeclarationAst(QualifierTypeDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
-            if (!string.IsNullOrEmpty(node.Name.Name))
+            if (!string.IsNullOrEmpty(node.QualifierName.Name))
             {
-                source.Append(node.Name.Name);
+                source.Append(node.QualifierName.Name);
             }
             if (node.Initializer != null)
             {
@@ -197,10 +197,10 @@ namespace Kingsland.MofParser.CodeGen
             var lastQualifierName = default(string);
 
             source.Append("[");
-            for (var i = 0; i < node.Qualifiers.Count; i++)
+            for (var i = 0; i < node.QualifierValues.Count; i++)
             {
-                var thisQualifier = node.Qualifiers[i];
-                var thisQualifierName = thisQualifier.QualifierName.GetNormalizedName();
+                var thisQualifierValue = node.QualifierValues[i];
+                var thisQualifierName = thisQualifierValue.QualifierName.GetNormalizedName();
                 if (i > 0)
                 {
                     source.Append(",");
@@ -209,7 +209,7 @@ namespace Kingsland.MofParser.CodeGen
                         source.Append(" ");
                     }
                 }
-                source.Append(MofGenerator.ConvertQualifierValueAst(thisQualifier, quirks));
+                source.Append(MofGenerator.ConvertQualifierValueAst(thisQualifierValue, quirks));
                 lastQualifierName = thisQualifierName;
             }
             source.Append("]");
@@ -263,9 +263,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertStructureDeclarationAst(StructureDeclarationAst node, MofQuirks quirks = MofQuirks.None, string indent = "")
         {
             var source = new StringBuilder();
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
                 source.Append(indent);
             }
             source.Append($"{Constants.STRUCTURE} {node.StructureName.Name}");
@@ -276,11 +276,11 @@ namespace Kingsland.MofParser.CodeGen
             source.AppendLine();
             source.Append(indent);
             source.AppendLine("{");
-            foreach (var feature in node.Features)
+            foreach (var structureFeature in node.Features)
             {
                 source.Append(indent);
                 source.Append("\t");
-                source.AppendLine(MofGenerator.ConvertStructureFeatureAst(feature, quirks, indent + '\t'));
+                source.AppendLine(MofGenerator.ConvertStructureFeatureAst(structureFeature, quirks, indent + '\t'));
             }
             source.Append(indent);
             source.Append("};");
@@ -309,7 +309,7 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertClassDeclarationAst(ClassDeclarationAst node, MofQuirks quirks = MofQuirks.None, string indent = "")
         {
             var source = new StringBuilder();
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if ((node.Qualifiers != null) && node.Qualifiers.QualifierValues.Count > 0)
             {
                 source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
                 source.Append(indent);
@@ -354,9 +354,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertAssociationDeclarationAst(AssociationDeclarationAst node, MofQuirks quirks = MofQuirks.None, string indent = "")
         {
             var source = new StringBuilder();
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
                 source.Append(indent);
             }
             source.Append($"{Constants.ASSOCIATION} {node.AssociationName.Name}");
@@ -385,9 +385,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertEnumerationDeclarationAst(EnumerationDeclarationAst node, MofQuirks quirks = MofQuirks.None, string indent = "")
         {
             var source = new StringBuilder();
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.AppendLine(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
                 source.Append(indent);
             }
             source.Append($"{Constants.ENUMERATION} {node.EnumName.Name}");
@@ -414,9 +414,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertEnumElementAst(EnumElementAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
                 source.Append(" ");
             }
             source.Append(node.EnumElementName.Name);
@@ -448,9 +448,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertPropertyDeclarationAst(PropertyDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
                 source.Append(" ");
             }
             source.Append(node.ReturnType.Name);
@@ -485,12 +485,12 @@ namespace Kingsland.MofParser.CodeGen
 
             var source = new StringBuilder();
 
-            if ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
             }
 
-            if (prefixQuirkEnabled || ((node.Qualifiers != null) && node.Qualifiers.Qualifiers.Count > 0))
+            if (prefixQuirkEnabled || (node.QualifierList.QualifierValues.Count > 0))
             {
                 source.Append(" ");
             }
@@ -520,9 +520,9 @@ namespace Kingsland.MofParser.CodeGen
         public static string ConvertParameterDeclarationAst(ParameterDeclarationAst node, MofQuirks quirks = MofQuirks.None)
         {
             var source = new StringBuilder();
-            if (node.Qualifiers.Qualifiers.Count > 0)
+            if (node.QualifierList.QualifierValues.Count > 0)
             {
-                source.Append(MofGenerator.ConvertQualifierListAst(node.Qualifiers, quirks));
+                source.Append(MofGenerator.ConvertQualifierListAst(node.QualifierList, quirks));
                 source.Append(" ");
             }
             source.Append(node.ParameterType.Name);

--- a/src/Kingsland.MofParser/Parsing/ParserEngine.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserEngine.cs
@@ -255,14 +255,14 @@ namespace Kingsland.MofParser.Parsing
             var peek = stream.Peek<BlockOpenToken>();
             if (peek != null)
             {
-                node.Qualifiers = ParserEngine.ParseQualifierListAst(stream);
+                node.QualifierList = ParserEngine.ParseQualifierListAst(stream);
             }
 
             // QUALIFIER
             stream.ReadIdentifier(Constants.QUALIFIER);
 
             // qualifierName
-            node.Name = stream.Read<IdentifierToken>();
+            node.QualifierName = stream.Read<IdentifierToken>();
 
             // ":"
             stream.Read<ColonToken>();
@@ -310,14 +310,14 @@ namespace Kingsland.MofParser.Parsing
 
             // qualifierValue
             qualifierValue = ParserEngine.ParseQualifierValueAst(stream);
-            node.Qualifiers.Add(qualifierValue);
+            node.QualifierValues.Add(qualifierValue);
 
             // *( "," qualifierValue )
             while (stream.Peek<CommaToken>() != null)
             {
                 var commaToken = stream.Read<CommaToken>();
                 qualifierValue = ParserEngine.ParseQualifierValueAst(stream);
-                node.Qualifiers.Add(qualifierValue);
+                node.QualifierValues.Add(qualifierValue);
             }
 
             // "]"
@@ -531,7 +531,7 @@ namespace Kingsland.MofParser.Parsing
             var node = new StructureDeclarationAst.Builder();
 
             // [ qualifierList ]
-            node.Qualifiers = qualifiers;
+            node.QualifierList = qualifiers;
 
             // STRUCTURE
             stream.ReadIdentifier(Constants.STRUCTURE);
@@ -870,7 +870,7 @@ namespace Kingsland.MofParser.Parsing
         ///     parameterList     = parameterDeclaration *( "," parameterDeclaration )
         ///
         public static IClassFeatureAst ParseMemberDeclaration(
-            ParserStream stream, QualifierListAst qualifiers,
+            ParserStream stream, QualifierListAst qualifierList,
             bool allowPropertyDeclaration, bool allowMethodDeclaration
         )
         {
@@ -1027,7 +1027,7 @@ namespace Kingsland.MofParser.Parsing
                 }
                 var node = new PropertyDeclarationAst.Builder
                 {
-                    Qualifiers = qualifiers,
+                    QualifierList = qualifierList,
                     ReturnType = memberReturnType,
                     ReturnTypeRef = memberReturnTypeRef,
                     PropertyName = memberName,
@@ -1045,7 +1045,7 @@ namespace Kingsland.MofParser.Parsing
                 }
                 var node = new MethodDeclarationAst.Builder
                 {
-                    Qualifiers = qualifiers,
+                    QualifierList = qualifierList,
                     ReturnType = memberReturnType,
                     ReturnTypeRef = memberReturnTypeRef,
                     ReturnTypeIsArray = methodReturnTypeIsArray,
@@ -1111,13 +1111,13 @@ namespace Kingsland.MofParser.Parsing
         ///     ASSOCIATION            = "association" ; keyword: case insensitive
         ///
         /// </remarks>
-        public static AssociationDeclarationAst ParseAssociationDeclarationAst(ParserStream stream, QualifierListAst qualifiers)
+        public static AssociationDeclarationAst ParseAssociationDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
         {
 
             var node = new AssociationDeclarationAst.Builder();
 
             // [ qualifierList ]
-            node.Qualifiers = qualifiers;
+            node.QualifierList = qualifierList;
 
             // ASSOCIATION
             stream.ReadIdentifier(Constants.ASSOCIATION);
@@ -1197,7 +1197,7 @@ namespace Kingsland.MofParser.Parsing
         ///     ENUMERATION            = "enumeration" ; keyword: case insensitive
         ///
         /// </remarks>
-        public static EnumerationDeclarationAst ParseEnumerationDeclarationAst(ParserStream stream, QualifierListAst qualifiers)
+        public static EnumerationDeclarationAst ParseEnumerationDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
         {
 
             var node = new EnumerationDeclarationAst.Builder();
@@ -1207,7 +1207,7 @@ namespace Kingsland.MofParser.Parsing
 
             // [ qualifierList ]
             // note - this has already been read for us and gets passed in as a parameter
-            node.Qualifiers = qualifiers;
+            node.QualifierList = qualifierList;
 
             // ENUMERATION
             var enumeration = stream.ReadIdentifier(Constants.ENUMERATION);
@@ -1293,7 +1293,7 @@ namespace Kingsland.MofParser.Parsing
             // [ qualifierList ]
             if (stream.Peek<AttributeOpenToken>() != null)
             {
-                node.Qualifiers = ParserEngine.ParseQualifierListAst(stream);
+                node.QualifierList = ParserEngine.ParseQualifierListAst(stream);
             }
             // enumLiteral
             node.EnumElementName = stream.ReadIdentifier();
@@ -1365,10 +1365,10 @@ namespace Kingsland.MofParser.Parsing
         {
 
             // [ qualifierList ]
-            var qualifiers = default(QualifierListAst);
+            var qualifierList = default(QualifierListAst);
             if (stream.Peek<AttributeOpenToken>() != null)
             {
-                qualifiers = ParserEngine.ParseQualifierListAst(stream);
+                qualifierList = ParserEngine.ParseQualifierListAst(stream);
             }
 
             // read the type of the parameter
@@ -1415,7 +1415,7 @@ namespace Kingsland.MofParser.Parsing
             }
 
             return new ParameterDeclarationAst.Builder {
-                Qualifiers = qualifiers,
+                QualifierList = qualifierList,
                 ParameterType = parameterTypeName,
                 ParameterRef = parameterRef,
                 ParameterName = parameterName,


### PR DESCRIPTION
Renamed "Qualifier" properties (e.g. Qualifiers => QualifierList) to match MOF spec names