### PR TITLE
Added ParserQuirks and qualifier "flavors"

### DIFF
--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -1249,6 +1249,19 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
         {
 
             [Test]
+            public static void EmptyEnumValueArrayShouldRoundtrip()
+            {
+                RoundtripTests.AssertRoundtrip(
+                    "instance of GOLF_Date\r\n" +
+                    "{\r\n" +
+                    "\tYear = 2011;\r\n" +
+                    "\tMonth = {June};\r\n" +
+                    "\tDay = 31;\r\n" +
+                    "};"
+                );
+            }
+
+            [Test]
             public static void EnumValueArrayWithSingleEnumValueShouldRoundtrip()
             {
                 RoundtripTests.AssertRoundtrip(
@@ -1272,13 +1285,38 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
             }
 
             [Test(Description = "https://github.com/mikeclayton/MofParser/issues/25")]
-            public static void EnumValueArrayWithQualifiedEnumValuesShouldRoundtrip()
+            public static void EnumValueArrayWithQualifiedEnumValuesAndQuirksEnabledShouldRoundtrip()
             {
                 RoundtripTests.AssertRoundtrip(
                     "instance of GOLF_Date\r\n" +
                     "{\r\n" +
                     "\tMonth = {MonthEnums.July};\r\n" +
-                    "};"
+                    "};",
+                    ParserQuirks.EnumValueArrayContainsEnumValuesNotEnumNames
+                );
+            }
+
+            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/25")]
+            public static void EnumValueArrayWithQualifiedEnumValuesAndQuirksDisabledShouldThrow()
+            {
+                var sourceMof =
+                    "instance of GOLF_Date\r\n" +
+                    "{\r\n" +
+                    "\tMonth = {MonthEnums.July};\r\n" +
+                    "};";
+                var tokens = Lexing.Lexer.Lex(SourceReader.From(sourceMof));
+                var tokensMof = TokenMofGenerator.ConvertToMof(tokens);
+                var ex = Assert.Throws<UnexpectedTokenException>(
+                    () =>
+                    {
+                        var astNodes = Parser.Parse(tokens);
+                    }
+                );
+                Assert.AreEqual(
+                    "Unexpected token found at Position 46, Line Number 3, Column Number 21.\r\n" +
+                    "Token Type: 'DotOperatorToken'\r\n" +
+                    "Token Text: '.'",
+                    ex.Message
                 );
             }
 

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -462,6 +462,50 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 );
             }
 
+            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/52")]
+            public static void EnumerationDeclarationDeprecatedMof300IntegerBaseAndQuirksEnabledShouldThrow()
+            {
+                // this should throw because "uint32" is recognized as an integer type.
+                // as a result, "July" (a string) is not a valid value for an integer enumElement value
+                var sourceMof =
+                    "enumeration MonthsEnum : uint32\r\n" +
+                    "{\r\n" +
+                    "\tJuly = \"July\"\r\n" +
+                    "};";
+                var tokens = Lexing.Lexer.Lex(SourceReader.From(sourceMof));
+                var tokensMof = TokenMofGenerator.ConvertToMof(tokens);
+                var ex = Assert.Throws<UnexpectedTokenException>(
+                    () =>
+                    {
+                        var astNodes = Parser.Parse(
+                            tokens,
+                            ParserQuirks.AllowDeprecatedMof300IntegerTypesAsEnumerationDeclarationsBase
+                        );
+                    }
+                );
+                Assert.AreEqual(
+                    "Unexpected token found at Position 44, Line Number 3, Column Number 9.\r\n" +
+                    "Token Type: 'StringLiteralToken'\r\n" +
+                    "Token Text: '\"July\"'",
+                    ex.Message
+                );
+            }
+
+            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/52")]
+            public static void EnumerationDeclarationDeprecatedMof300IntegerBaseAndQuirksDisabledShouldRoundtrip()
+            {
+                // this should roundtrip because "uint32" is not recognized as an integer type, and
+                // so it's assumed to be a separate base enum like "enumeration uint32 { ... };".
+                // as a result, there's no validation done on the datattype of the enum element and
+                // it will accept "July" as a valid value
+                RoundtripTests.AssertRoundtrip(
+                    "enumeration MonthsEnum : uint32\r\n" +
+                    "{\r\n" +
+                    "\tJuly = \"July\"\r\n" +
+                    "};"
+                );
+            }
+
         }
 
         public static class EnumElementTests
@@ -553,6 +597,24 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 );
             }
 
+            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/28")]
+            public static void PropertyDeclarationWithDeprecatedMof300IntegerReturnTypesAndQuirksDisabledShouldRoundtrip()
+            {
+                RoundtripTests.AssertRoundtrip(
+                    "class GOLF_Base\r\n" +
+                    "{\r\n" +
+                    "\tuint8 SeverityUint8;\r\n" +
+                    "\tuint16 SeverityUint16;\r\n" +
+                    "\tuint32 SeverityUint32;\r\n" +
+                    "\tuint64 SeverityUint64;\r\n" +
+                    "\tsint8 SeveritySint8;\r\n" +
+                    "\tsint16 SeveritySint16;\r\n" +
+                    "\tsint32 SeveritySint32;\r\n" +
+                    "\tsint64 SeveritySint64;\r\n" +
+                    "};"
+                );
+            }
+
         }
 
         #endregion
@@ -617,18 +679,6 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 );
             }
 
-            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/28"),
-             Ignore("https://github.com/mikeclayton/MofParser/issues/28")]
-            public static void ClassDeclarationsWithMethodDeclarationWithDeprecatedPrimtitiveValueTypeInitializerShouldRoundtrip()
-            {
-                RoundtripTests.AssertRoundtrip(
-                    "class Win32_SoftwareFeature : CIM_SoftwareFeature\r\n" +
-                    "{\r\n" +
-                    "\tuint32 Reinstall(uint16 ReinstallMode = 1);\r\n" +
-                    "};"
-                );
-            }
-
             [Test(Description = "https://github.com/mikeclayton/MofParser/issues/37")]
             public static void MethodDeclarationsWithArrayReturnTypeShouldRoundtrip()
             {
@@ -647,6 +697,42 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                     "class GOLF_Professional : GOLF_ClubMember\r\n" +
                     "{\r\n" +
                     "\tGOLF_ResultCodeEnum GetNumberOfProfessionals(Integer NoOfPros, GOLF_Club Club, ProfessionalStatusEnum Status = Professional);\r\n" +
+                    "};"
+                );
+            }
+
+            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/28")]
+            public static void MethodDeclarationWithDeprecatedMof300IntegerReturnTypesAndQuirksDisabledShouldRoundtrip()
+            {
+                RoundtripTests.AssertRoundtrip(
+                    "class Win32_SoftwareFeature : CIM_SoftwareFeature\r\n" +
+                    "{\r\n" +
+                    "\tuint8 ReinstallUint8(integer ReinstallMode = 1);\r\n" +
+                    "\tuint16 ReinstallUint16(integer ReinstallMode = 1);\r\n" +
+                    "\tuint32 ReinstallUint32(integer ReinstallMode = 1);\r\n" +
+                    "\tuint64 ReinstallUint64(integer ReinstallMode = 1);\r\n" +
+                    "\tsint8 ReinstallUint8(integer ReinstallMode = 1);\r\n" +
+                    "\tsint16 ReinstallUint16(integer ReinstallMode = 1);\r\n" +
+                    "\tsint32 ReinstallUint32(integer ReinstallMode = 1);\r\n" +
+                    "\tsint64 ReinstallUint64(integer ReinstallMode = 1);\r\n" +
+                    "};"
+                );
+            }
+
+            [Test(Description = "https://github.com/mikeclayton/MofParser/issues/28")]
+            public static void MethodDeclarationWithDeprecatedMof300IntegerParameterTypesShouldRoundtrip()
+            {
+                RoundtripTests.AssertRoundtrip(
+                    "class Win32_SoftwareFeature : CIM_SoftwareFeature\r\n" +
+                    "{\r\n" +
+                    "\tinteger ReinstallUint8(uint8 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint16(uint16 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint32(uint32 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint64(uint64 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint8(sint8 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint16(sint16 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint32(sint32 ReinstallMode = 1);\r\n" +
+                    "\tinteger ReinstallUint64(sint64 ReinstallMode = 1);\r\n" +
                     "};"
                 );
             }
@@ -850,7 +936,7 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 );
             }
 
-            [Test, Ignore("")]
+            [Test]
             public static void PositiveIntegerValueShouldRoundtrip()
             {
                 RoundtripTests.AssertRoundtrip(
@@ -896,7 +982,6 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                     "};"
                 );
             }
-
 
         }
 

--- a/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/CodeGen/MofGeneratorTests.cs
@@ -34,6 +34,80 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
 
         #endregion
 
+        #region 7.4 Qualifiers
+
+        public static class QualifierTests
+        {
+
+            [Test]
+            public static void QualifierShouldRoundtrip()
+            {
+                RoundtripTests.AssertRoundtrip(
+                    "[Description(\"Instances of this class represent golf clubs. A golf club is \" \"an organization that provides member services to golf players \" \"both amateur and professional.\")]\r\n" +
+                    "class GOLF_Club : GOLF_Base\r\n" +
+                    "{\r\n" +
+                    "};"
+                );
+            }
+
+        }
+
+        #endregion
+
+        #region 7.4.1 QualifierList
+
+        public static class QualifierListTests
+        {
+
+        }
+
+        public static class ParseQualifierValueTests
+        {
+
+            [Test]
+            public static void QualifierWithMofV2FlavorsAndQuirksEnabledShouldRoundtrip()
+            {
+                RoundtripTests.AssertRoundtrip(
+                    "[Locale(1033): ToInstance, UUID(\"{BE46D060-7A7C-11d2-BC85-00104B2CF71C}\"): ToInstance]\r\n" +
+                    "class Win32_PrivilegesStatus : __ExtendedStatus\r\n" +
+                    "{\r\n" +
+                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesNotHeld[];\r\n" +
+                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesRequired[];\r\n" +
+                    "};",
+                    ParserQuirks.AllowMofV2Qualifiers
+                );
+            }
+
+            [Test]
+            public static void QualifierWithMofV2FlavorsAndQuirksDisabledShouldThrow()
+            {
+                var sourceMof =
+                    "[Locale(1033): ToInstance, UUID(\"{BE46D060-7A7C-11d2-BC85-00104B2CF71C}\"): ToInstance]\r\n" +
+                    "class Win32_PrivilegesStatus : __ExtendedStatus\r\n" +
+                    "{\r\n" +
+                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesNotHeld[];\r\n" +
+                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesRequired[];\r\n" +
+                    "};";
+                var tokens = Lexing.Lexer.Lex(SourceReader.From(sourceMof));
+                var tokensMof = TokenMofGenerator.ConvertToMof(tokens);
+                var ex = Assert.Throws<UnexpectedTokenException>(
+                    () =>
+                    {
+                        var astNodes = Parser.Parse(tokens);
+                    }
+                );
+                Assert.AreEqual(
+                    "Unexpected token found at Position 13, Line Number 1, Column Number 14.\r\n" +
+                    "Token Type: 'ColonToken'\r\n" +
+                    "Token Text: ':'",
+                    ex.Message
+                );
+            }
+
+        }
+
+        #endregion
+
         #region 7.5.1 Structure declaration
 
         public static class StructureDeclarationTests
@@ -91,19 +165,25 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
             [Test]
             public static void InvalidStructureFeatureShouldThrow()
             {
-                var expectedMof =
+
+                var sourceMof =
                     "structure Sponsor\r\n" +
                     "{\r\n" +
                     "\t100\r\n" +
                     "};";
-                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
-                Assert.Throws<UnexpectedTokenException>(
+                var tokens = Lexing.Lexer.Lex(SourceReader.From(sourceMof));
+                var tokensMof = TokenMofGenerator.ConvertToMof(tokens);
+                Assert.AreEqual(sourceMof, tokensMof);
+                var ex = Assert.Throws<UnexpectedTokenException>(
                     () => {
-                        var actualAst = Parser.Parse(actualTokens);
-                    },
+                        var astNodes = Parser.Parse(tokens);
+                    }
+                );
+                Assert.AreEqual(
                     "Unexpected token found at Position 23, Line Number 3, Column Number 2.\r\n" +
                     "Token Type: 'IntegerLiteralToken'\r\n" +
-                    "Token Text: '100'"
+                    "Token Text: '100'",
+                    ex.Message
                 );
             }
 
@@ -200,19 +280,6 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
                 );
             }
 
-            [Test]
-            public static void ClassDeclarationsAstWithMofV2QualifierFlavorsShouldRoundtrip()
-            {
-                RoundtripTests.AssertRoundtrip(
-                    "[Locale(1033): ToInstance, UUID(\"{BE46D060-7A7C-11d2-BC85-00104B2CF71C}\"): ToInstance]\r\n" +
-                    "class Win32_PrivilegesStatus : __ExtendedStatus\r\n" +
-                    "{\r\n" +
-                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesNotHeld[];\r\n" +
-                    "\t[read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesRequired[];\r\n" +
-                    "};"
-                );
-            }
-
         }
 
         public static class ClassFeatureTests
@@ -232,19 +299,23 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
             [Test]
             public static void InvalidClassFeatureShouldThrow()
             {
-                var expectedMof =
+                var sourceMof =
                     "class Sponsor\r\n" +
                     "{\r\n" +
                     "\t100\r\n" +
                     "};";
-                var actualTokens = Lexing.Lexer.Lex(SourceReader.From(expectedMof));
-                Assert.Throws<UnexpectedTokenException>(
+                var tokens = Lexing.Lexer.Lex(SourceReader.From(sourceMof));
+                var tokensMof = TokenMofGenerator.ConvertToMof(tokens);
+                var ex = Assert.Throws<UnexpectedTokenException>(
                     () => {
-                        var actualAst = Parser.Parse(actualTokens);
-                    },
-                    "Unexpected token found at Position 23, Line Number 3, Column Number 2.\r\n" +
+                        var astNodes = Parser.Parse(tokens);
+                    }
+                );
+                Assert.AreEqual(
+                    "Unexpected token found at Position 19, Line Number 3, Column Number 2.\r\n" +
                     "Token Type: 'IntegerLiteralToken'\r\n" +
-                    "Token Text: '100'"
+                    "Token Text: '100'",
+                    ex.Message
                 );
             }
 
@@ -1251,14 +1322,14 @@ namespace Kingsland.MofParser.UnitTests.CodeGen
         //    }
         //}
 
-        private static void AssertRoundtrip(string sourceMof)
+        private static void AssertRoundtrip(string sourceMof, ParserQuirks parserQuirks = ParserQuirks.None)
         {
             // check the lexer tokens roundtrips ok
             var tokens = Lexing.Lexer.Lex(SourceReader.From(sourceMof));
             var tokensMof = TokenMofGenerator.ConvertToMof(tokens);
             Assert.AreEqual(sourceMof, tokensMof);
             // check the parser ast roundtrips ok
-            var astNodes  = Parser.Parse(tokens);
+            var astNodes = Parser.Parse(tokens, parserQuirks);
             var astMof = AstMofGenerator.ConvertToMof(astNodes);
             Assert.AreEqual(sourceMof, astMof);
         }

--- a/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
+++ b/src/Kingsland.MofParser.UnitTests/Parsing/ParserTests.cs
@@ -15,7 +15,8 @@ namespace Kingsland.MofParser.UnitTests.Parsing
     public static class ParserTests
     {
 
-        [TestFixture]
+        #region 7.5.9 Complex type value
+
         public static class PropertyValueTests
         {
 
@@ -620,6 +621,8 @@ namespace Kingsland.MofParser.UnitTests.Parsing
             }
 
         }
+
+        #endregion
 
         //[TestFixture]
         //private static class ParseMethodTestCasesWmiWin81

--- a/src/Kingsland.MofParser/Kingsland.MofParser.csproj
+++ b/src/Kingsland.MofParser/Kingsland.MofParser.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Ast\ClassDeclarationAst.cs" />
     <Compile Include="Ast\ComplexTypeValueAst.cs" />
     <Compile Include="CodeGen\TokenMofGenerator.cs" />
+    <Compile Include="Parsing\ParserQuirks.cs" />
     <Compile Include="Tokens\DotOperatorToken.cs" />
     <Compile Include="Tokens\IntegerKind.cs" />
     <Compile Include="Ast\PropertyValueListAst.cs" />

--- a/src/Kingsland.MofParser/Parsing/Constants.cs
+++ b/src/Kingsland.MofParser/Parsing/Constants.cs
@@ -52,6 +52,16 @@
         public const string DT_BOOLEAN = "boolean";
         public const string DT_OCTECTSTRING = "octetstring";
 
+        // deprecated in MOF 3.0.1, but defined here to support parser quirks
+        public const string DT_UINT8 = "uint8";
+        public const string DT_UINT16 = "uint16";
+        public const string DT_UINT32 = "uint32";
+        public const string DT_UINT64 = "uint64";
+        public const string DT_SINT8 = "sint8";
+        public const string DT_SINT16 = "sint16";
+        public const string DT_SINT32 = "sint32";
+        public const string DT_SINT64 = "sint64";
+
         // 7.5.9 Complex type value
         public const string INSTANCE = "instance";
         public const string VALUE = "value";

--- a/src/Kingsland.MofParser/Parsing/Parser.cs
+++ b/src/Kingsland.MofParser/Parsing/Parser.cs
@@ -9,7 +9,7 @@ namespace Kingsland.MofParser.Parsing
     public static class Parser
     {
 
-        public static MofSpecificationAst Parse(List<Token> lexerTokens)
+        public static MofSpecificationAst Parse(List<Token> lexerTokens, ParserQuirks quirks = ParserQuirks.None)
         {
 
             // remove all comments and whitespace
@@ -17,7 +17,7 @@ namespace Kingsland.MofParser.Parsing
                                                  !(lt is WhitespaceToken)).ToList();
 
             var stream = new ParserStream(tokens);
-            var program = ParserEngine.ParseMofSpecificationAst(stream);
+            var program = ParserEngine.ParseMofSpecificationAst(stream, quirks);
 
             return program;
 

--- a/src/Kingsland.MofParser/Parsing/ParserEngine.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserEngine.cs
@@ -25,13 +25,13 @@ namespace Kingsland.MofParser.Parsing
         ///     mofSpecification = *mofProduction
         ///
         /// </remarks>
-        public static MofSpecificationAst ParseMofSpecificationAst(ParserStream stream)
+        public static MofSpecificationAst ParseMofSpecificationAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             var node = new MofSpecificationAst.Builder();
             while (!stream.Eof)
             {
                 node.Productions.Add(
-                    ParserEngine.ParseMofProductionAst(stream)
+                    ParserEngine.ParseMofProductionAst(stream, quirks)
                 );
             }
             return node.Build();
@@ -102,7 +102,7 @@ namespace Kingsland.MofParser.Parsing
         ///                                 [ qualifierPolicy ] ";"
         ///
         /// </remarks>
-        public static MofProductionAst ParseMofProductionAst(ParserStream stream)
+        public static MofProductionAst ParseMofProductionAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var peek = stream.Peek();
@@ -110,7 +110,7 @@ namespace Kingsland.MofParser.Parsing
             // compilerDirective
             if (peek is PragmaToken)
             {
-                return ParserEngine.ParseCompilerDirectiveAst(stream);
+                return ParserEngine.ParseCompilerDirectiveAst(stream, quirks);
             }
 
             if (peek is IdentifierToken identifier)
@@ -119,10 +119,10 @@ namespace Kingsland.MofParser.Parsing
                 {
                     case Constants.VALUE:
                         // structureValueDeclaration
-                        return ParserEngine.ParseStructureValueDeclarationAst(stream);
+                        return ParserEngine.ParseStructureValueDeclarationAst(stream, quirks);
                     case Constants.INSTANCE:
                         // instanceValueDeclaration
-                        return ParserEngine.ParseInstanceValueDeclarationAst(stream);
+                        return ParserEngine.ParseInstanceValueDeclarationAst(stream, quirks);
                 }
             }
 
@@ -130,7 +130,7 @@ namespace Kingsland.MofParser.Parsing
             var qualifierList = default(QualifierListAst);
             if (peek is AttributeOpenToken)
             {
-                qualifierList = ParserEngine.ParseQualifierListAst(stream);
+                qualifierList = ParserEngine.ParseQualifierListAst(stream, quirks);
             }
 
             identifier = stream.Peek<IdentifierToken>();
@@ -138,19 +138,19 @@ namespace Kingsland.MofParser.Parsing
             {
                 case Constants.STRUCTURE:
                     // structureDeclaration
-                    return ParserEngine.ParseStructureDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseStructureDeclarationAst(stream, qualifierList, quirks);
                 case Constants.CLASS:
                     // classDeclaration
-                    return ParserEngine.ParseClassDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseClassDeclarationAst(stream, qualifierList, quirks);
                 case Constants.ASSOCIATION:
                     // associationDeclaration
-                    return ParserEngine.ParseAssociationDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseAssociationDeclarationAst(stream, qualifierList, quirks);
                 case Constants.ENUMERATION:
                     // enumerationDeclaration
-                    return ParserEngine.ParseEnumerationDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseEnumerationDeclarationAst(stream, qualifierList, quirks);
                 case Constants.QUALIFIER:
                     // qualifierTypeDeclaration
-                    return ParserEngine.ParseQualifierTypeDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseQualifierTypeDeclarationAst(stream, qualifierList, quirks);
                 default:
                     throw new UnexpectedTokenException(identifier);
             }
@@ -190,7 +190,7 @@ namespace Kingsland.MofParser.Parsing
         ///     directiveName      = org-id "_" IDENTIFIER
         ///
         /// </remarks>
-        public static CompilerDirectiveAst ParseCompilerDirectiveAst(ParserStream stream)
+        public static CompilerDirectiveAst ParseCompilerDirectiveAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new CompilerDirectiveAst.Builder();
@@ -205,7 +205,7 @@ namespace Kingsland.MofParser.Parsing
             var parenthesisOpen = stream.Read<ParenthesisOpenToken>();
 
             // pragmaParameter
-            node.PragmaParameter = ParserEngine.ParseStringValueAst(stream);
+            node.PragmaParameter = ParserEngine.ParseStringValueAst(stream, quirks);
 
             // ")"
             var parenthesisClose = stream.Read<ParenthesisCloseToken>();
@@ -244,7 +244,7 @@ namespace Kingsland.MofParser.Parsing
         ///     qualifierScope           = SCOPE "(" ANY / scopeKindList ")"
         ///
         /// </returns>
-        public static QualifierTypeDeclarationAst ParseQualifierTypeDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
+        public static QualifierTypeDeclarationAst ParseQualifierTypeDeclarationAst(ParserStream stream, QualifierListAst qualifierList, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new QualifierTypeDeclarationAst.Builder();
@@ -293,7 +293,7 @@ namespace Kingsland.MofParser.Parsing
         ///     qualifierList = "[" qualifierValue *( "," qualifierValue ) "]"
         ///
         /// </remarks>
-        public static QualifierListAst ParseQualifierListAst(ParserStream stream)
+        public static QualifierListAst ParseQualifierListAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new QualifierListAst.Builder();
@@ -303,14 +303,14 @@ namespace Kingsland.MofParser.Parsing
 
             // qualifierValue
             node.QualifierValues.Add(
-                ParserEngine.ParseQualifierValueAst(stream)
+                ParserEngine.ParseQualifierValueAst(stream, quirks)
             );
 
             // *( "," qualifierValue )
             while (stream.TryRead<CommaToken>(out var comma))
             {
                 node.QualifierValues.Add(
-                    ParserEngine.ParseQualifierValueAst(stream)
+                    ParserEngine.ParseQualifierValueAst(stream, quirks)
                 );
             }
 
@@ -339,7 +339,7 @@ namespace Kingsland.MofParser.Parsing
         ///     qualifierName  = elementName
         ///
         /// </remarks>
-        public static QualifierValueAst ParseQualifierValueAst(ParserStream stream)
+        public static QualifierValueAst ParseQualifierValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new QualifierValueAst.Builder();
@@ -354,43 +354,21 @@ namespace Kingsland.MofParser.Parsing
             {
                 case ParenthesisOpenToken paranthesesOpen:
                     // qualifierValueInitializer
-                    node.ValueInitializer = ParserEngine.ParseQualifierValueInitializer(stream);
+                    node.ValueInitializer = ParserEngine.ParseQualifierValueInitializer(stream, quirks);
                     break;
                 case BlockOpenToken blockOpen:
                     // qualiferValueArrayInitializer
-                    node.ValueArrayInitializer = ParserEngine.ParseQualifierValueArrayInitializer(stream);
+                    node.ValueArrayInitializer = ParserEngine.ParseQualifierValueArrayInitializer(stream, quirks);
                     break;
             }
 
-            //
-            // 7.4 Qualifiers
-            //
-            // NOTE A MOF v2 qualifier declaration has to be converted to MOF v3 qualifierTypeDeclaration because the
-            // MOF v2 qualifier flavor has been replaced by the MOF v3 qualifierPolicy.
-            //
-            // In MOF V2, the ColonToken separates qualifier "values" and "flavors", e.g:
-            //
-            //     [Locale(1033): ToInstance, UUID("{BE46D060-7A7C-11d2-BC85-00104B2CF71C}"): ToInstance]
-            //     class Win32_PrivilegesStatus : __ExtendedStatus
-            //     {
-            //         [read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesNotHeld[];
-            //         [read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesRequired[];
-            //     }
-            //
-            // but this is no longer valid in MOF V3.
-            //
-            // We'll read them anyway for compatibility.
-            //
             // Pseudo-ABNF for MOF V2 qualifiers:
             //
             //     qualifierList_v2       = "[" qualifierValue_v2 *( "," qualifierValue_v2 ) "]"
             //     qualifierValue_v2      = qualifierName [ qualifierValueInitializer / qualiferValueArrayInitializer ] ":" qualifierFlavourList_v2
             //     qualifierFlavorList_v2 = qualifierFlavorName *( " " qualifierFlavorName )
-            //
-
-            var allowV2QUalifierFlavors = true;
-
-            if (allowV2QUalifierFlavors)
+            var quirkEnabled = (quirks & ParserQuirks.AllowMofV2Qualifiers) == ParserQuirks.AllowMofV2Qualifiers;
+            if (quirkEnabled)
             {
                 if (stream.TryRead<ColonToken>(out var colon))
                 {
@@ -419,12 +397,12 @@ namespace Kingsland.MofParser.Parsing
         ///     qualifierValueInitializer = "(" literalValue ")"
         ///
         /// </remarks>
-        public static LiteralValueAst ParseQualifierValueInitializer(ParserStream stream)
+        public static LiteralValueAst ParseQualifierValueInitializer(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             // "("
             var parenthesisOpen = stream.Read<ParenthesisOpenToken>();
             // literalValue
-            var node = ParserEngine.ParseLiteralValueAst(stream);
+            var node = ParserEngine.ParseLiteralValueAst(stream, quirks);
             // ")"
             var parenthesisClose = stream.Read<ParenthesisCloseToken>();
             return node;
@@ -443,7 +421,7 @@ namespace Kingsland.MofParser.Parsing
         ///     qualiferValueArrayInitializer = "{" literalValue *( "," literalValue ) "}"
         ///
         /// </remarks>
-        public static LiteralValueArrayAst ParseQualifierValueArrayInitializer(ParserStream stream)
+        public static LiteralValueArrayAst ParseQualifierValueArrayInitializer(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new LiteralValueArrayAst.Builder();
@@ -469,14 +447,14 @@ namespace Kingsland.MofParser.Parsing
 
                 // literalValue
                 node.Values.Add(
-                    ParserEngine.ParseLiteralValueAst(stream)
+                    ParserEngine.ParseLiteralValueAst(stream, quirks)
                 );
 
                 // *( "," literalValue )
                 while (stream.TryRead<CommaToken>(out var comma))
                 {
                     node.Values.Add(
-                        ParserEngine.ParseLiteralValueAst(stream)
+                        ParserEngine.ParseLiteralValueAst(stream, quirks)
                     );
                 }
 
@@ -519,7 +497,7 @@ namespace Kingsland.MofParser.Parsing
         ///     STRUCTURE            = "structure" ; keyword: case insensitive
         ///
         /// </remarks>
-        public static StructureDeclarationAst ParseStructureDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
+        public static StructureDeclarationAst ParseStructureDeclarationAst(ParserStream stream, QualifierListAst qualifierList, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new StructureDeclarationAst.Builder();
@@ -554,7 +532,7 @@ namespace Kingsland.MofParser.Parsing
             while (!stream.TryPeek<BlockCloseToken>())
             {
                 node.StructureFeatures.Add(
-                    ParserEngine.ParseStructureFeatureAst(stream)
+                    ParserEngine.ParseStructureFeatureAst(stream, quirks)
                 );
             }
 
@@ -612,14 +590,14 @@ namespace Kingsland.MofParser.Parsing
         ///                                    [ "=" referenceTypeValue ]
         ///
         /// </remarks>
-        public static IStructureFeatureAst ParseStructureFeatureAst(ParserStream stream)
+        public static IStructureFeatureAst ParseStructureFeatureAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             // all structureFeatures start with an optional "[ qualifierList ]"
             var qualifierList = default(QualifierListAst);
             if (stream.TryPeek<AttributeOpenToken>())
             {
-                qualifierList = ParserEngine.ParseQualifierListAst(stream);
+                qualifierList = ParserEngine.ParseQualifierListAst(stream, quirks);
             }
 
             // we now need to work out if it's a structureDeclaration, enumerationDeclaration,
@@ -638,13 +616,13 @@ namespace Kingsland.MofParser.Parsing
             {
                 case Constants.STRUCTURE:
                     // structureDeclaration
-                    return ParserEngine.ParseStructureDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseStructureDeclarationAst(stream, qualifierList, quirks);
                 case Constants.ENUMERATION:
                     // enumerationDeclaration
-                    return ParserEngine.ParseEnumerationDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseEnumerationDeclarationAst(stream, qualifierList, quirks);
                 default:
                     // propertyDeclaration
-                    return ParserEngine.ParsePropertyDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParsePropertyDeclarationAst(stream, qualifierList, quirks);
             }
 
         }
@@ -675,7 +653,7 @@ namespace Kingsland.MofParser.Parsing
         ///     CLASS            = "class" ; keyword: case insensitive
         ///
         /// </remarks>
-        public static ClassDeclarationAst ParseClassDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
+        public static ClassDeclarationAst ParseClassDeclarationAst(ParserStream stream, QualifierListAst qualifierList, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new ClassDeclarationAst.Builder();
@@ -710,7 +688,7 @@ namespace Kingsland.MofParser.Parsing
             while (!stream.TryPeek<BlockCloseToken>())
             {
                 node.ClassFeatures.Add(
-                    ParserEngine.ParseClassFeatureAst(stream)
+                    ParserEngine.ParseClassFeatureAst(stream, quirks)
                 );
             }
 
@@ -752,14 +730,14 @@ namespace Kingsland.MofParser.Parsing
         ///     enumTypeHeader         = [qualifierList] ENUMERATION
         ///
         /// </remarks>
-        public static IClassFeatureAst ParseClassFeatureAst(ParserStream stream)
+        public static IClassFeatureAst ParseClassFeatureAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             // all classFeatures start with an optional "[ qualifierList ]"
             var qualifierList = default(QualifierListAst);
             if (stream.TryPeek<AttributeOpenToken>())
             {
-                qualifierList = ParserEngine.ParseQualifierListAst(stream);
+                qualifierList = ParserEngine.ParseQualifierListAst(stream, quirks);
             }
 
             // we now need to work out if it's a structureDeclaration, enumerationDeclaration,
@@ -774,13 +752,13 @@ namespace Kingsland.MofParser.Parsing
             {
                 case Constants.STRUCTURE:
                     // structureDeclaration
-                    return ParserEngine.ParseStructureDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseStructureDeclarationAst(stream, qualifierList, quirks);
                 case Constants.ENUMERATION:
                     // enumerationDeclaration
-                    return ParserEngine.ParseEnumerationDeclarationAst(stream, qualifierList);
+                    return ParserEngine.ParseEnumerationDeclarationAst(stream, qualifierList, quirks);
                 default:
                     // propertyDeclaration or methodDeclaration
-                    return ParserEngine.ParseMemberDeclarationAst(stream, qualifierList, true, true);
+                    return ParserEngine.ParseMemberDeclarationAst(stream, qualifierList, true, true, quirks);
             }
 
         }
@@ -809,7 +787,7 @@ namespace Kingsland.MofParser.Parsing
         ///     ASSOCIATION            = "association" ; keyword: case insensitive
         ///
         /// </remarks>
-        public static AssociationDeclarationAst ParseAssociationDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
+        public static AssociationDeclarationAst ParseAssociationDeclarationAst(ParserStream stream, QualifierListAst qualifierList, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new AssociationDeclarationAst.Builder();
@@ -843,7 +821,7 @@ namespace Kingsland.MofParser.Parsing
             while (!stream.TryPeek<BlockCloseToken>())
             {
                 node.ClassFeatures.Add(
-                    ParserEngine.ParseClassFeatureAst(stream)
+                    ParserEngine.ParseClassFeatureAst(stream, quirks)
                 );
             }
 
@@ -888,7 +866,7 @@ namespace Kingsland.MofParser.Parsing
         ///     ENUMERATION            = "enumeration" ; keyword: case insensitive
         ///
         /// </remarks>
-        public static EnumerationDeclarationAst ParseEnumerationDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
+        public static EnumerationDeclarationAst ParseEnumerationDeclarationAst(ParserStream stream, QualifierListAst qualifierList, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new EnumerationDeclarationAst.Builder();
@@ -942,13 +920,13 @@ namespace Kingsland.MofParser.Parsing
             {
                 // integerEnumElement / stringEnumElement
                 node.EnumElements.Add(
-                    ParserEngine.ParseEnumElementAst(stream, isIntegerEnum, isStringEnum)
+                    ParserEngine.ParseEnumElementAst(stream, isIntegerEnum, isStringEnum, quirks)
                 );
                 // *( "," integerEnumElement ) / *( "," stringEnumElement )
                 while (stream.TryRead<CommaToken>(out var comma))
                 {
                     node.EnumElements.Add(
-                        ParserEngine.ParseEnumElementAst(stream, isIntegerEnum, isStringEnum)
+                        ParserEngine.ParseEnumElementAst(stream, isIntegerEnum, isStringEnum, quirks)
                     );
                 }
             }
@@ -978,7 +956,7 @@ namespace Kingsland.MofParser.Parsing
         ///     enumLiteral        = IDENTIFIER
         ///
         /// </remarks>
-        public static EnumElementAst ParseEnumElementAst(ParserStream stream, bool isIntegerEnum, bool isStringEnum)
+        public static EnumElementAst ParseEnumElementAst(ParserStream stream, bool isIntegerEnum, bool isStringEnum, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new EnumElementAst.Builder();
@@ -986,7 +964,7 @@ namespace Kingsland.MofParser.Parsing
             // [ qualifierList ]
             if (stream.TryPeek<AttributeOpenToken>())
             {
-                node.QualifierList = ParserEngine.ParseQualifierListAst(stream);
+                node.QualifierList = ParserEngine.ParseQualifierListAst(stream, quirks);
             }
 
             // enumLiteral
@@ -1000,11 +978,11 @@ namespace Kingsland.MofParser.Parsing
                 {
                     case IntegerLiteralToken integerValue:
                         // integerValue
-                        node.EnumElementValue = ParserEngine.ParseIntegerValueAst(stream);
+                        node.EnumElementValue = ParserEngine.ParseIntegerValueAst(stream, quirks);
                         break;
                     case StringLiteralToken stringValue:
                         // stringValue
-                        node.EnumElementValue = ParserEngine.ParseStringValueAst(stream);
+                        node.EnumElementValue = ParserEngine.ParseStringValueAst(stream, quirks);
                         break;
                     default:
                         throw new UnsupportedTokenException(enumValue);
@@ -1039,9 +1017,9 @@ namespace Kingsland.MofParser.Parsing
         ///                                    referencePropertyDeclaration) ";"
         ///
         /// </remarks>
-        public static PropertyDeclarationAst ParsePropertyDeclarationAst(ParserStream stream, QualifierListAst qualifierList)
+        public static PropertyDeclarationAst ParsePropertyDeclarationAst(ParserStream stream, QualifierListAst qualifierList, ParserQuirks quirks = ParserQuirks.None)
         {
-            return (PropertyDeclarationAst)ParserEngine.ParseMemberDeclarationAst(stream, qualifierList, true, false);
+            return (PropertyDeclarationAst)ParserEngine.ParseMemberDeclarationAst(stream, qualifierList, true, false, quirks);
         }
 
         /// <summary>
@@ -1097,7 +1075,8 @@ namespace Kingsland.MofParser.Parsing
         ///
         public static IClassFeatureAst ParseMemberDeclarationAst(
             ParserStream stream, QualifierListAst qualifierList,
-            bool allowPropertyDeclaration, bool allowMethodDeclaration
+            bool allowPropertyDeclaration, bool allowMethodDeclaration,
+            ParserQuirks quirks
         )
         {
 
@@ -1184,13 +1163,13 @@ namespace Kingsland.MofParser.Parsing
                 {
                     // parameterDeclaration
                     methodParameterDeclarations.Add(
-                        ParserEngine.ParseParameterDeclarationAst(stream)
+                        ParserEngine.ParseParameterDeclarationAst(stream, quirks)
                     );
                     // *( "," parameterDeclaration )
                     while (stream.TryRead<CommaToken>(out var comma))
                     {
                         methodParameterDeclarations.Add(
-                            ParserEngine.ParseParameterDeclarationAst(stream)
+                            ParserEngine.ParseParameterDeclarationAst(stream, quirks)
                         );
                     }
                 }
@@ -1230,7 +1209,7 @@ namespace Kingsland.MofParser.Parsing
                     }
                     // "="
                     var equalsOperator = stream.Read<EqualsOperatorToken>();
-                    propertyInitializer = ParserEngine.ParsePropertyValueAst(stream);
+                    propertyInitializer = ParserEngine.ParsePropertyValueAst(stream, quirks);
                 }
             }
 
@@ -1323,14 +1302,14 @@ namespace Kingsland.MofParser.Parsing
         ///     DT_REFERENCE              = className REF
         ///
         /// </remarks>
-        public static ParameterDeclarationAst ParseParameterDeclarationAst(ParserStream stream)
+        public static ParameterDeclarationAst ParseParameterDeclarationAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             // [ qualifierList ]
             var qualifierList = default(QualifierListAst);
             if (stream.TryPeek<AttributeOpenToken>())
             {
-                qualifierList = ParserEngine.ParseQualifierListAst(stream);
+                qualifierList = ParserEngine.ParseQualifierListAst(stream, quirks);
             }
 
             // read the type of the parameter
@@ -1368,7 +1347,7 @@ namespace Kingsland.MofParser.Parsing
             var parameterDefaultValue = default(PropertyValueAst);
             if (stream.TryRead<EqualsOperatorToken>(out var equals))
             {
-                parameterDefaultValue = ParserEngine.ParsePropertyValueAst(stream);
+                parameterDefaultValue = ParserEngine.ParsePropertyValueAst(stream, quirks);
             }
 
             return new ParameterDeclarationAst.Builder {
@@ -1398,17 +1377,17 @@ namespace Kingsland.MofParser.Parsing
         ///     complexTypeValue = complexValue / complexValueArray
         ///
         /// </remarks>
-        public static ComplexTypeValueAst ParseComplexTypeValueAst(ParserStream stream)
+        public static ComplexTypeValueAst ParseComplexTypeValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             if (!stream.TryPeek<BlockOpenToken>())
             {
                 // complexValue
-                return ParserEngine.ParseComplexValueAst(stream);
+                return ParserEngine.ParseComplexValueAst(stream, quirks);
             }
             else
             {
                 // complexValueArray
-                return ParserEngine.ParseComplexValueArrayAst(stream);
+                return ParserEngine.ParseComplexValueArrayAst(stream, quirks);
             }
         }
 
@@ -1424,7 +1403,7 @@ namespace Kingsland.MofParser.Parsing
         ///     complexValueArray = "{" [ complexValue *( "," complexValue) ] "}"
         ///
         /// </remarks>
-        public static ComplexValueArrayAst ParseComplexValueArrayAst(ParserStream stream)
+        public static ComplexValueArrayAst ParseComplexValueArrayAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             // complexValueArray =
@@ -1437,14 +1416,14 @@ namespace Kingsland.MofParser.Parsing
 
                 // complexValue
                 node.Values.Add(
-                    ParserEngine.ParseComplexValueAst(stream)
+                    ParserEngine.ParseComplexValueAst(stream, quirks)
                 );
 
                 // *( "," complexValue)
                 while (stream.TryRead<CommaToken>(out var comma))
                 {
                     node.Values.Add(
-                        ParserEngine.ParseComplexValueAst(stream)
+                        ParserEngine.ParseComplexValueAst(stream, quirks)
                     );
                 }
 
@@ -1473,7 +1452,7 @@ namespace Kingsland.MofParser.Parsing
         ///                      propertyValueList )
         ///
         /// </remarks>
-        public static ComplexValueAst ParseComplexValueAst(ParserStream stream)
+        public static ComplexValueAst ParseComplexValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new ComplexValueAst.Builder();
@@ -1502,7 +1481,7 @@ namespace Kingsland.MofParser.Parsing
                 );
 
                 // propertyValueList
-                node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream);
+                node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream, quirks);
 
             }
 
@@ -1527,7 +1506,7 @@ namespace Kingsland.MofParser.Parsing
         ///     propertyName      = IDENTIFIER
         ///
         /// </remarks>
-        internal static PropertyValueListAst ParsePropertyValueListAst(ParserStream stream)
+        internal static PropertyValueListAst ParsePropertyValueListAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new PropertyValueListAst.Builder();
@@ -1550,7 +1529,7 @@ namespace Kingsland.MofParser.Parsing
                     stream.Read<EqualsOperatorToken>();
 
                     // propertyValue
-                    var propertyValue = ParserEngine.ParsePropertyValueAst(stream);
+                    var propertyValue = ParserEngine.ParsePropertyValueAst(stream, quirks);
 
                     // ";"
                     stream.Read<StatementEndToken>();
@@ -1602,7 +1581,7 @@ namespace Kingsland.MofParser.Parsing
         ///     enumLiteral    = IDENTIFIER
         ///
         /// </remarks>
-        internal static PropertyValueAst ParsePropertyValueAst(ParserStream stream)
+        internal static PropertyValueAst ParsePropertyValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             bool IsPrimitiveValueToken(Token token)
@@ -1642,7 +1621,7 @@ namespace Kingsland.MofParser.Parsing
                     // this is an empty array, so just pick a default type for now.
                     // (we probably need a "public sealed class UnknownTypeValue : PropertyValueAst"
                     // if we ever start doing type analysis on the ast).
-                    return ParserEngine.ParsePrimitiveTypeValueAst(stream);
+                    return ParserEngine.ParsePrimitiveTypeValueAst(stream, quirks);
                 }
             }
 
@@ -1650,22 +1629,22 @@ namespace Kingsland.MofParser.Parsing
             if (IsPrimitiveValueToken(itemValue))
             {
                 // primitiveTypeValue = literalValue / literalValueArray
-                node = ParserEngine.ParsePrimitiveTypeValueAst(stream);
+                node = ParserEngine.ParsePrimitiveTypeValueAst(stream, quirks);
             }
             else if (IsComplexValueToken(itemValue))
             {
                 // complexTypeValue = complexValue / complexValueArray
-                node = ParserEngine.ParseComplexTypeValueAst(stream);
+                node = ParserEngine.ParseComplexTypeValueAst(stream, quirks);
             }
             else if (IsReferenceValueToken(itemValue))
             {
                 // referenceTypeValue = objectPathValue / objectPathValueArray
-                node = ParserEngine.ParseReferenceTypeValueAst(stream);
+                node = ParserEngine.ParseReferenceTypeValueAst(stream, quirks);
             }
             else
             {
                 // enumTypeValue = enumValue / enumValueArray
-                node = ParserEngine.ParseEnumTypeValueAst(stream);
+                node = ParserEngine.ParseEnumTypeValueAst(stream, quirks);
             }
 
             // return the result
@@ -1689,17 +1668,17 @@ namespace Kingsland.MofParser.Parsing
         ///     primitiveTypeValue = literalValue / literalValueArray
         ///
         /// </remarks>
-        public static PrimitiveTypeValueAst ParsePrimitiveTypeValueAst(ParserStream stream)
+        public static PrimitiveTypeValueAst ParsePrimitiveTypeValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             if (!stream.TryPeek<BlockOpenToken>())
             {
                 // literalValue
-                return ParserEngine.ParseLiteralValueAst(stream);
+                return ParserEngine.ParseLiteralValueAst(stream, quirks);
             }
             else
             {
                 // literalValueArray
-                return ParserEngine.ParseLiteralValueArrayAst(stream);
+                return ParserEngine.ParseLiteralValueArrayAst(stream, quirks);
             }
         }
 
@@ -1715,7 +1694,7 @@ namespace Kingsland.MofParser.Parsing
         ///     literalValueArray = "{" [ literalValue *( "," literalValue ) ] "}"
         ///
         /// </remarks>
-        public static LiteralValueArrayAst ParseLiteralValueArrayAst(ParserStream stream)
+        public static LiteralValueArrayAst ParseLiteralValueArrayAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             var node = new LiteralValueArrayAst.Builder();
             // "{"
@@ -1725,13 +1704,13 @@ namespace Kingsland.MofParser.Parsing
             {
                 // literalValue
                 node.Values.Add(
-                    ParserEngine.ParseLiteralValueAst(stream)
+                    ParserEngine.ParseLiteralValueAst(stream, quirks)
                 );
                 // *( "," literalValue )
                 while (stream.TryRead<CommaToken>(out var comma))
                 {
                     node.Values.Add(
-                        ParserEngine.ParseLiteralValueAst(stream)
+                        ParserEngine.ParseLiteralValueAst(stream, quirks)
                     );
                 }
             }
@@ -1760,26 +1739,26 @@ namespace Kingsland.MofParser.Parsing
         ///                      ; dateTimeValue
         ///
         /// </remarks>
-        public static LiteralValueAst ParseLiteralValueAst(ParserStream stream)
+        public static LiteralValueAst ParseLiteralValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             var peek = stream.Peek();
             switch (peek)
             {
                 case IntegerLiteralToken integerLiteral:
                     // integerValue
-                    return ParserEngine.ParseIntegerValueAst(stream);
+                    return ParserEngine.ParseIntegerValueAst(stream, quirks);
                 case RealLiteralToken realLiteral:
                     // realValue
-                    return ParserEngine.ParseRealValueAst(stream);
+                    return ParserEngine.ParseRealValueAst(stream, quirks);
                 case BooleanLiteralToken booleanLiteral:
                     // booleanValue
-                    return ParserEngine.ParseBooleanValueAst(stream);
+                    return ParserEngine.ParseBooleanValueAst(stream, quirks);
                 case NullLiteralToken nullLiteral:
                     // nullValue
-                    return ParserEngine.ParseNullValueAst(stream);
+                    return ParserEngine.ParseNullValueAst(stream, quirks);
                 case StringLiteralToken stringLiteral:
                     // stringValue
-                    return ParserEngine.ParseStringValueAst(stream);
+                    return ParserEngine.ParseStringValueAst(stream, quirks);
                 default:
                     throw new UnexpectedTokenException(peek);
             }
@@ -1803,7 +1782,7 @@ namespace Kingsland.MofParser.Parsing
         ///     integerValue = binaryValue / octalValue / hexValue / decimalValue
         ///
         /// </remarks>
-        public static IntegerValueAst ParseIntegerValueAst(ParserStream stream)
+        public static IntegerValueAst ParseIntegerValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             var node = new IntegerValueAst.Builder();
             node.IntegerLiteralToken = stream.Read<IntegerLiteralToken>();
@@ -1831,7 +1810,7 @@ namespace Kingsland.MofParser.Parsing
         ///     positiveDecimalDigit = "1"..."9"
         ///
         /// </remarks>
-        public static RealValueAst ParseRealValueAst(ParserStream stream)
+        public static RealValueAst ParseRealValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             var node = new RealValueAst.Builder();
             node.RealLiteralToken = stream.Read<RealLiteralToken>();
@@ -1857,7 +1836,7 @@ namespace Kingsland.MofParser.Parsing
         ///     stringValue       = singleStringValue *( *WS singleStringValue )
         ///
         /// </remarks>
-        public static StringValueAst ParseStringValueAst(ParserStream stream)
+        public static StringValueAst ParseStringValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new StringValueAst.Builder();
@@ -1902,7 +1881,7 @@ namespace Kingsland.MofParser.Parsing
         ///     TRUE         = "true"  ; keyword: case insensitive
         ///
         /// </remarks>
-        public static BooleanValueAst ParseBooleanValueAst(ParserStream stream)
+        public static BooleanValueAst ParseBooleanValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             return new BooleanValueAst(
                 stream.Read<BooleanLiteralToken>()
@@ -1929,7 +1908,7 @@ namespace Kingsland.MofParser.Parsing
         ///                        ; second
         ///
         /// </remarks>
-        public static NullValueAst ParseNullValueAst(ParserStream stream)
+        public static NullValueAst ParseNullValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             return new NullValueAst.Builder
             {
@@ -1958,7 +1937,7 @@ namespace Kingsland.MofParser.Parsing
         ///     alias                    = AS aliasIdentifier
         ///
         /// </remarks>
-        public static InstanceValueDeclarationAst ParseInstanceValueDeclarationAst(ParserStream stream)
+        public static InstanceValueDeclarationAst ParseInstanceValueDeclarationAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new InstanceValueDeclarationAst.Builder();
@@ -1987,7 +1966,7 @@ namespace Kingsland.MofParser.Parsing
             }
 
             // propertyValueList
-            node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream);
+            node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream, quirks);
 
             // ";"
             node.StatementEnd = stream.Read<StatementEndToken>();
@@ -2014,7 +1993,7 @@ namespace Kingsland.MofParser.Parsing
         ///     alias                     = AS aliasIdentifier
         ///
         /// </remarks>
-        public static StructureValueDeclarationAst ParseStructureValueDeclarationAst(ParserStream stream)
+        public static StructureValueDeclarationAst ParseStructureValueDeclarationAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new StructureValueDeclarationAst.Builder();
@@ -2044,7 +2023,7 @@ namespace Kingsland.MofParser.Parsing
             }
 
             // propertyValueList
-            node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream);
+            node.PropertyValues = ParserEngine.ParsePropertyValueListAst(stream, quirks);
 
             // ";"
             node.StatementEnd = stream.Read<StatementEndToken>();
@@ -2070,17 +2049,17 @@ namespace Kingsland.MofParser.Parsing
         ///     enumTypeValue = enumValue / enumValueArray
         ///
         /// </remarks>
-        public static EnumTypeValueAst ParseEnumTypeValueAst(ParserStream stream)
+        public static EnumTypeValueAst ParseEnumTypeValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             if (!stream.TryPeek<BlockOpenToken>())
             {
                 // enumValue
-                return ParserEngine.ParseEnumValueAst(stream);
+                return ParserEngine.ParseEnumValueAst(stream, quirks);
             }
             else
             {
                 // enumValueArray
-                return ParserEngine.ParseEnumValueArrayAst(stream);
+                return ParserEngine.ParseEnumValueArrayAst(stream, quirks);
             }
         }
 
@@ -2117,7 +2096,7 @@ namespace Kingsland.MofParser.Parsing
         ///     nextSchemaChar      = firstSchemaChar / decimalDigit
         ///
         /// </remarks>
-        public static EnumValueAst ParseEnumValueAst(ParserStream stream)
+        public static EnumValueAst ParseEnumValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new EnumValueAst.Builder();
@@ -2163,7 +2142,7 @@ namespace Kingsland.MofParser.Parsing
         ///     enumValueArray = "{" [ enumName *( "," enumName ) ] "}"
         ///
         /// </remarks>
-        public static EnumValueArrayAst ParseEnumValueArrayAst(ParserStream stream)
+        public static EnumValueArrayAst ParseEnumValueArrayAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
 
             var node = new EnumValueArrayAst.Builder();
@@ -2178,14 +2157,14 @@ namespace Kingsland.MofParser.Parsing
 
                 // enumValue
                 node.Values.Add(
-                    ParserEngine.ParseEnumValueAst(stream)
+                    ParserEngine.ParseEnumValueAst(stream, quirks)
                 );
 
                 // *( "," enumValue )
                 while (stream.TryRead<CommaToken>(out var comma))
                 {
                     node.Values.Add(
-                        ParserEngine.ParseEnumValueAst(stream)
+                        ParserEngine.ParseEnumValueAst(stream, quirks)
                     );
                 }
 
@@ -2214,17 +2193,17 @@ namespace Kingsland.MofParser.Parsing
         ///     referenceTypeValue = objectPathValue / objectPathValueArray
         ///
         /// </remarks>
-        public static PrimitiveTypeValueAst ParseReferenceTypeValueAst(ParserStream stream)
+        public static PrimitiveTypeValueAst ParseReferenceTypeValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             if (stream.TryPeek<BlockOpenToken>())
             {
                 // objectPathValueArray
-                return ParserEngine.ParseObjectPathValueArrayAst(stream);
+                return ParserEngine.ParseObjectPathValueArrayAst(stream, quirks);
             }
             else
             {
                 // objectPathValue
-                return ParserEngine.ParseObjectPathValueAst(stream);
+                return ParserEngine.ParseObjectPathValueAst(stream, quirks);
             }
         }
 
@@ -2253,7 +2232,7 @@ namespace Kingsland.MofParser.Parsing
         ///     keyValue         = propertyName "=" literalValue
         ///
         /// </remarks>
-        public static PrimitiveTypeValueAst ParseObjectPathValueAst(ParserStream stream)
+        public static PrimitiveTypeValueAst ParseObjectPathValueAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             throw new NotImplementedException();
         }
@@ -2269,7 +2248,7 @@ namespace Kingsland.MofParser.Parsing
         ///     objectPathValueArray = "{" [ objectPathValue *( "," objectPathValue ) ]
         ///
         /// </remarks>
-        public static PrimitiveTypeValueAst ParseObjectPathValueArrayAst(ParserStream stream)
+        public static PrimitiveTypeValueAst ParseObjectPathValueArrayAst(ParserStream stream, ParserQuirks quirks = ParserQuirks.None)
         {
             throw new NotImplementedException();
         }

--- a/src/Kingsland.MofParser/Parsing/ParserQuirks.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserQuirks.cs
@@ -33,7 +33,7 @@ namespace Kingsland.MofParser.Parsing
         /// If this quirk is enabled we'll read qualifier flavors anyway for compatibility witn MOF V2 mof files.
         ///
         /// </remarks>
-        AllowMofV2Qualifiers = 1,
+        AllowMofV2Qualifiers = 0x0001,
 
         /// <summary>
         /// Allows deprecated qualifier "flavors" to be used in MOF files.
@@ -60,7 +60,59 @@ namespace Kingsland.MofParser.Parsing
         /// If this quirk is enabled we'll assume enum array entries are enumValues instead of enumNames.
         ///
         /// </remarks>
-        EnumValueArrayContainsEnumValuesNotEnumNames = 2
+        EnumValueArrayContainsEnumValuesNotEnumNames = 0x0002,
+
+        /// <summary>
+        /// Allows use of deprecated integer types - int8, int16, uint8, uint16, etc
+        /// </summary>
+        /// <remarks>
+        ///
+        /// See https://github.com/mikeclayton/MofParser/issues/28
+        ///
+        /// The MOF Spec 3.0.1 deprecated a number of integer datatypes defined in MOF SPec 3.0.0:
+        ///
+        ///     // MOF Spec 3.0.0
+        ///     DT_Integer         = DT_UnsignedInteger / DT_SignedInteger
+        ///     DT_UnsignedInteger = "uint8" / "uint16" / "uint32"/ "uint64"
+        ///     DT_SignedInteger   = "sint8" / "sint16" / "sint32" / "sint64"
+        ///
+        /// became
+        ///
+        ///     // MOF Spec 3.0.1
+        ///     DT_Integer         = "integer"
+        ///
+        /// which means 'uint32' is valid as a base enum type in MOF 3.0.0 but not MOF 3.0.1
+        ///
+        ///     enum MyEnum : uint32
+        ///     {
+        ///     };
+        ///
+        /// If this quirk is enabled we'll allow deprectated integer types in enumeration declarations.
+        ///
+        /// </remarks>
+        AllowDeprecatedMof300IntegerTypesAsEnumerationDeclarationsBase = 0x0004,
+
+        /// <summary>
+        /// Allows use of empty qualifier value arrays.
+        /// </summary>
+        /// <remarks>
+        ///
+        /// See https://github.com/mikeclayton/MofParser/issues/51
+        ///
+        /// The MOF 3.0.1 spec doesn't allow for empty qualifier value arrays like
+        /// "{}" in this property from the "MSMCAEvent_InvalidError" class in WinXpProSp3WMI.mof:
+        ///
+        ///	    [WmiDataId(3), ValueMap{}] uint32 Type;
+        ///
+        /// It's presumably allowed in earlier versions of the MOF spec, or maybe the
+        /// System.Management.ManagementBaseObject.GetFormat method returns invalid MOF
+        /// text for some classes, but we'll provide an option to allow or disallow empty
+        /// arrays here...
+        ///
+        /// If this quirk is enabled we'll allow empty qualifier value array.
+        ///
+        /// </remarks>
+        AllowEmptyQualifierValueArrays = 0x0008
 
     }
 

--- a/src/Kingsland.MofParser/Parsing/ParserQuirks.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserQuirks.cs
@@ -13,6 +13,9 @@ namespace Kingsland.MofParser.Parsing
         /// Allows deprecated qualifier "flavors" to be used in MOF files.
         /// </summary>
         /// <remarks>
+        ///
+        /// See https://github.com/mikeclayton/MofParser/issues/49
+        ///
         /// A MOF v2 qualifier declaration has to be converted to MOF v3 qualifierTypeDeclaration because the
         /// MOF v2 qualifier flavor has been replaced by the MOF v3 qualifierPolicy.
         ///
@@ -28,8 +31,36 @@ namespace Kingsland.MofParser.Parsing
         /// but this is no longer valid in MOF V3.
         ///
         /// If this quirk is enabled we'll read qualifier flavors anyway for compatibility witn MOF V2 mof files.
+        ///
         /// </remarks>
         AllowMofV2Qualifiers = 1,
+
+        /// <summary>
+        /// Allows deprecated qualifier "flavors" to be used in MOF files.
+        /// </summary>
+        /// <remarks>
+        ///
+        /// See https://github.com/mikeclayton/MofParser/issues/25
+        ///
+        /// Enum value arrays are defined in the MOF 3.0.1 spec as:
+        ///
+        ///     enumValueArray = "{" [ enumName *( "," enumName ) ] "}"
+        ///
+        /// but should *probably* be
+        ///
+        ///     enumValueArray = "{" [ enumValue *( "," enumValue ) ] "}"
+        ///
+        /// because this is invalid otherwise:
+        ///
+        ///     instance of MY_Class
+        ///     {
+        ///         Months = { MonthEnum.January, MonthEnum.April, MonthEnum.June, MonthEnum.September };
+        ///     };
+        ///
+        /// If this quirk is enabled we'll assume enum array entries are enumValues instead of enumNames.
+        ///
+        /// </remarks>
+        EnumValueArrayContainsEnumValuesNotEnumNames = 2
 
     }
 

--- a/src/Kingsland.MofParser/Parsing/ParserQuirks.cs
+++ b/src/Kingsland.MofParser/Parsing/ParserQuirks.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Kingsland.MofParser.Parsing
+{
+
+    [Flags]
+    public enum ParserQuirks
+    {
+
+        None = 0,
+
+        /// <summary>
+        /// Allows deprecated qualifier "flavors" to be used in MOF files.
+        /// </summary>
+        /// <remarks>
+        /// A MOF v2 qualifier declaration has to be converted to MOF v3 qualifierTypeDeclaration because the
+        /// MOF v2 qualifier flavor has been replaced by the MOF v3 qualifierPolicy.
+        ///
+        /// In MOF V2, the ColonToken separates qualifier "values" and "flavors", e.g:
+        ///
+        ///     [Locale(1033): ToInstance, UUID("{BE46D060-7A7C-11d2-BC85-00104B2CF71C}"): ToInstance]
+        ///     class Win32_PrivilegesStatus : __ExtendedStatus
+        ///     {
+        ///         [read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesNotHeld[];
+        ///         [read: ToSubClass, MappingStrings{\"Win32API|AccessControl|Windows NT Privileges\"}: ToSubClass] string PrivilegesRequired[];
+        ///     }
+        ///
+        /// but this is no longer valid in MOF V3.
+        ///
+        /// If this quirk is enabled we'll read qualifier flavors anyway for compatibility witn MOF V2 mof files.
+        /// </remarks>
+        AllowMofV2Qualifiers = 1,
+
+    }
+
+}

--- a/src/Kingsland.MofParser/Parsing/UnsupportedTokenException.cs
+++ b/src/Kingsland.MofParser/Parsing/UnsupportedTokenException.cs
@@ -48,7 +48,7 @@ namespace Kingsland.MofParser.Parsing
                     var startPosition = extent.StartPosition;
                     var endPosition = extent.EndPosition;
                     return $"Unhandled token found at Position {startPosition.Position}, Line Number {startPosition.LineNumber}, Column Number {startPosition.ColumnNumber}.\r\n" +
-                           $"Token Type: '{token.GetType().FullName}'\r\n" +
+                           $"Token Type: '{token.GetType().Name}'\r\n" +
                            $"Token Text: '{extent.Text}'";
                 }
             }


### PR DESCRIPTION
Added ParserQuirks to allow control of ParserEngine behaviour
Fixed #49 - Support for MOF V2 qualifier flavours
Fixed #48 - Errors in "Assert.Throws" unit tests